### PR TITLE
Add wasm/web target with QR-pairing example

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -34,3 +34,13 @@ rustflags = ["-C", "link-arg=-Wl,-z,max-page-size=16384"]
 
 [target.i686-linux-android]
 rustflags = ["-C", "link-arg=-Wl,-z,max-page-size=16384"]
+
+# Browser/wasm32 build. `getrandom` 0.3 (pulled in via libp2p → yamux →
+# rand 0.9) requires both the `wasm_js` cargo feature *and* the
+# `getrandom_backend="wasm_js"` cfg to actually use the browser's
+# `crypto.getRandomValues` — without the cfg, the crate fails to compile
+# on wasm32 with "cannot find function `inner_u32` in module `backends`".
+# This must be set workspace-wide (not in wavesyncdb/Cargo.toml) because
+# rustflags can't be expressed there.
+[target.wasm32-unknown-unknown]
+rustflags = ['--cfg', 'getrandom_backend="wasm_js"']

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1813,7 +1813,7 @@ dependencies = [
  "pin-project",
  "reqwest",
  "rustversion",
- "send_wrapper",
+ "send_wrapper 0.6.0",
  "serde",
  "serde_json",
  "serde_qs",
@@ -2091,11 +2091,11 @@ dependencies = [
  "futures-channel",
  "futures-util",
  "generational-box",
- "gloo-timers",
+ "gloo-timers 0.3.0",
  "js-sys",
  "lazy-js-bundle",
  "rustc-hash 2.1.2",
- "send_wrapper",
+ "send_wrapper 0.6.0",
  "serde",
  "serde-wasm-bindgen",
  "serde_json",
@@ -2406,6 +2406,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "example-qr-pairing"
+version = "0.1.0"
+dependencies = [
+ "android_logger",
+ "dioxus",
+ "dioxus-sdk-storage",
+ "env_logger 0.11.10",
+ "getrandom 0.2.17",
+ "js-sys",
+ "log",
+ "qrcode",
+ "sea-orm",
+ "serde",
+ "serde_json",
+ "tokio",
+ "uuid",
+ "wasm-logger",
+ "wavesyncdb",
+ "web-sys",
+]
+
+[[package]]
 name = "example-wan"
 version = "0.1.0"
 dependencies = [
@@ -2635,6 +2657,10 @@ name = "futures-timer"
 version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
+dependencies = [
+ "gloo-timers 0.2.6",
+ "send_wrapper 0.4.0",
+]
 
 [[package]]
 name = "futures-util"
@@ -2743,6 +2769,18 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+]
+
+[[package]]
+name = "gloo-timers"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b995a66bb87bebce9a0f4a95aed01daca4872c050bfcb21653361c03bc35e5c"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -3101,7 +3139,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots",
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]
@@ -3284,6 +3322,21 @@ name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "idb"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6554f394e990a1af530a528a7fdcad6e01b29cb1b990f89df3ffd62cf15f7828"
+dependencies = [
+ "indexmap 2.14.0",
+ "js-sys",
+ "num-traits",
+ "thiserror 2.0.18",
+ "tokio",
+ "wasm-bindgen",
+ "web-sys",
+]
 
 [[package]]
 name = "ident_case"
@@ -3724,6 +3777,8 @@ dependencies = [
  "libp2p-swarm",
  "libp2p-tcp",
  "libp2p-upnp",
+ "libp2p-websocket",
+ "libp2p-websocket-websys",
  "libp2p-yamux",
  "multiaddr",
  "pin-project",
@@ -4114,14 +4169,17 @@ dependencies = [
  "fnv",
  "futures",
  "futures-timer",
+ "getrandom 0.2.17",
  "hashlink 0.10.0",
  "libp2p-core",
  "libp2p-identity",
+ "libp2p-swarm-derive",
  "multistream-select",
  "rand 0.8.5",
  "smallvec",
  "tokio",
  "tracing",
+ "wasm-bindgen-futures",
  "web-time",
 ]
 
@@ -4184,6 +4242,44 @@ dependencies = [
  "libp2p-swarm",
  "tokio",
  "tracing",
+]
+
+[[package]]
+name = "libp2p-websocket"
+version = "0.45.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520e29066a48674c007bc11defe5dce49908c24cafd8fad2f5e1a6a8726ced53"
+dependencies = [
+ "either",
+ "futures",
+ "futures-rustls",
+ "libp2p-core",
+ "libp2p-identity",
+ "parking_lot",
+ "pin-project-lite",
+ "rw-stream-sink",
+ "soketto",
+ "thiserror 2.0.18",
+ "tracing",
+ "url",
+ "webpki-roots 0.26.11",
+]
+
+[[package]]
+name = "libp2p-websocket-websys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e73d85b4dc8c2044f58508461bd8bb12f541217c0038ade8cce0ddc1607b8f72"
+dependencies = [
+ "bytes",
+ "futures",
+ "js-sys",
+ "libp2p-core",
+ "send_wrapper 0.6.0",
+ "thiserror 2.0.18",
+ "tracing",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -5466,6 +5562,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd348ff538bc9caeda7ee8cad2d1d48236a1f443c1fa3913c6a02fe0043b1dd3"
 
 [[package]]
+name = "qrcode"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d68782463e408eb1e668cf6152704bd856c78c5b6417adaee3203d8f4c1fc9ec"
+
+[[package]]
 name = "quick-protobuf"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5799,7 +5901,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "webpki-roots",
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]
@@ -6244,6 +6346,12 @@ checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "send_wrapper"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f638d531eccd6e23b980caf34876660d38e265409d8e99b397ab71eb3612fad0"
+
+[[package]]
+name = "send_wrapper"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
@@ -6545,6 +6653,21 @@ checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "soketto"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e859df029d160cb88608f5d7df7fb4753fd20fdfb4de5644f3d8b8440841721"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures",
+ "httparse",
+ "log",
+ "rand 0.8.5",
+ "sha1",
 ]
 
 [[package]]
@@ -7711,6 +7834,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-logger"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "074649a66bb306c8f2068c9016395fa65d8e08d2affcbf95acf3c24c3ab19718"
+dependencies = [
+ "log",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
 name = "wasm-metadata"
 version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7752,7 +7886,10 @@ name = "wavesync-website"
 version = "0.1.0"
 dependencies = [
  "dioxus",
+ "getrandom 0.2.17",
+ "js-sys",
  "pulldown-cmark",
+ "wavesyncdb",
 ]
 
 [[package]]
@@ -7787,8 +7924,13 @@ dependencies = [
  "dioxus",
  "env_logger 0.11.10",
  "futures",
+ "getrandom 0.2.17",
+ "getrandom 0.3.4",
+ "gloo-timers 0.3.0",
+ "idb",
  "inventory",
  "jni",
+ "js-sys",
  "libp2p",
  "libp2p-swarm-derive",
  "log",
@@ -7799,10 +7941,13 @@ dependencies = [
  "objc2-ui-kit",
  "sea-orm",
  "serde",
+ "serde-wasm-bindgen",
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
  "uuid",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
  "wavesyncdb_derive",
 ]
 
@@ -7872,6 +8017,15 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -2,6 +2,32 @@
 
 **Transparent peer-to-peer sync for SeaORM applications.**
 
+[![CI](https://img.shields.io/github/actions/workflow/status/pvg13/WaveSyncDB/rust.yml?branch=main&label=CI&logo=github)](https://github.com/pvg13/WaveSyncDB/actions/workflows/rust.yml)
+[![License](https://img.shields.io/badge/license-AGPL--3.0%20OR%20Commercial-blue)](LICENSE)
+[![Issues](https://img.shields.io/github/issues/pvg13/WaveSyncDB?logo=github)](https://github.com/pvg13/WaveSyncDB/issues)
+
+### Open issues by priority
+
+[![critical](https://img.shields.io/github/issues/pvg13/WaveSyncDB/priority:critical?label=critical&color=b60205)](https://github.com/pvg13/WaveSyncDB/issues?q=is%3Aopen+is%3Aissue+label%3A%22priority%3Acritical%22)
+[![high](https://img.shields.io/github/issues/pvg13/WaveSyncDB/priority:high?label=high&color=d93f0b)](https://github.com/pvg13/WaveSyncDB/issues?q=is%3Aopen+is%3Aissue+label%3A%22priority%3Ahigh%22)
+[![medium](https://img.shields.io/github/issues/pvg13/WaveSyncDB/priority:medium?label=medium&color=fbca04)](https://github.com/pvg13/WaveSyncDB/issues?q=is%3Aopen+is%3Aissue+label%3A%22priority%3Amedium%22)
+[![low](https://img.shields.io/github/issues/pvg13/WaveSyncDB/priority:low?label=low&color=0e8a16)](https://github.com/pvg13/WaveSyncDB/issues?q=is%3Aopen+is%3Aissue+label%3A%22priority%3Alow%22)
+[![design](https://img.shields.io/github/issues/pvg13/WaveSyncDB/priority:design?label=design&color=5319e7)](https://github.com/pvg13/WaveSyncDB/issues?q=is%3Aopen+is%3Aissue+label%3A%22priority%3Adesign%22)
+
+### Open issues by topic
+
+[![sync-protocol](https://img.shields.io/github/issues/pvg13/WaveSyncDB/topic:sync-protocol?label=sync-protocol&color=1d76db)](https://github.com/pvg13/WaveSyncDB/issues?q=is%3Aopen+is%3Aissue+label%3A%22topic%3Async-protocol%22)
+[![sql-parsing](https://img.shields.io/github/issues/pvg13/WaveSyncDB/topic:sql-parsing?label=sql-parsing&color=1d76db)](https://github.com/pvg13/WaveSyncDB/issues?q=is%3Aopen+is%3Aissue+label%3A%22topic%3Asql-parsing%22)
+[![shadow-tables](https://img.shields.io/github/issues/pvg13/WaveSyncDB/topic:shadow-tables?label=shadow-tables&color=1d76db)](https://github.com/pvg13/WaveSyncDB/issues?q=is%3Aopen+is%3Aissue+label%3A%22topic%3Ashadow-tables%22)
+[![p2p-networking](https://img.shields.io/github/issues/pvg13/WaveSyncDB/topic:p2p-networking?label=p2p-networking&color=1d76db)](https://github.com/pvg13/WaveSyncDB/issues?q=is%3Aopen+is%3Aissue+label%3A%22topic%3Ap2p-networking%22)
+[![dioxus](https://img.shields.io/github/issues/pvg13/WaveSyncDB/topic:dioxus?label=dioxus&color=1d76db)](https://github.com/pvg13/WaveSyncDB/issues?q=is%3Aopen+is%3Aissue+label%3A%22topic%3Adioxus%22)
+[![relay](https://img.shields.io/github/issues/pvg13/WaveSyncDB/topic:relay?label=relay&color=1d76db)](https://github.com/pvg13/WaveSyncDB/issues?q=is%3Aopen+is%3Aissue+label%3A%22topic%3Arelay%22)
+[![security](https://img.shields.io/github/issues/pvg13/WaveSyncDB/topic:security?label=security&color=1d76db)](https://github.com/pvg13/WaveSyncDB/issues?q=is%3Aopen+is%3Aissue+label%3A%22topic%3Asecurity%22)
+[![performance](https://img.shields.io/github/issues/pvg13/WaveSyncDB/topic:performance?label=performance&color=1d76db)](https://github.com/pvg13/WaveSyncDB/issues?q=is%3Aopen+is%3Aissue+label%3A%22topic%3Aperformance%22)
+[![lifecycle](https://img.shields.io/github/issues/pvg13/WaveSyncDB/topic:lifecycle?label=lifecycle&color=1d76db)](https://github.com/pvg13/WaveSyncDB/issues?q=is%3Aopen+is%3Aissue+label%3A%22topic%3Alifecycle%22)
+[![portability](https://img.shields.io/github/issues/pvg13/WaveSyncDB/topic:portability?label=portability&color=1d76db)](https://github.com/pvg13/WaveSyncDB/issues?q=is%3Aopen+is%3Aissue+label%3A%22topic%3Aportability%22)
+[![feature-request](https://img.shields.io/github/issues/pvg13/WaveSyncDB/feature-request?label=feature-request&color=a2eeef)](https://github.com/pvg13/WaveSyncDB/issues?q=is%3Aopen+is%3Aissue+label%3A%22feature-request%22)
+
 WaveSyncDB wraps your SeaORM `DatabaseConnection` and transparently intercepts write operations, replicating them across peers via libp2p gossipsub. Conflicts are resolved automatically using per-column Lamport clocks (CRDTs) — concurrent edits to different columns on the same row both survive, and all nodes converge deterministically. Your application code stays the same — just swap in `WaveSyncDb` and every insert, update, and delete syncs in the background.
 
 ## Quick Start

--- a/examples/bench/src/bin/bench_catchup.rs
+++ b/examples/bench/src/bin/bench_catchup.rs
@@ -69,9 +69,7 @@ async fn main() {
             break;
         }
         if Instant::now() > deadline {
-            panic!(
-                "timed out after {TIMEOUT_SECS}s — Peer B has only {count}/{N} rows"
-            );
+            panic!("timed out after {TIMEOUT_SECS}s — Peer B has only {count}/{N} rows");
         }
         tokio::time::sleep(Duration::from_millis(50)).await;
     }

--- a/examples/bench/src/bin/bench_conflict.rs
+++ b/examples/bench/src/bin/bench_conflict.rs
@@ -120,17 +120,17 @@ async fn main() {
             break a.clone();
         }
         if Instant::now() > deadline {
-            panic!(
-                "convergence timeout: a={:?} b={:?}",
-                a_title, b_title
-            );
+            panic!("convergence timeout: a={:?} b={:?}", a_title, b_title);
         }
         tokio::time::sleep(Duration::from_millis(50)).await;
     };
     let convergence_secs = conv_t.elapsed().as_secs_f64();
     let total = writes_done + convergence_secs;
 
-    println!("  Convergence after concurrent writes: {:.2}s", convergence_secs);
+    println!(
+        "  Convergence after concurrent writes: {:.2}s",
+        convergence_secs
+    );
     println!("  Total (writes + convergence):        {:.2}s", total);
     println!(
         "  Throughput (updates applied / total):    {:.0}/s",
@@ -166,10 +166,7 @@ async fn read_title(peer: &wavesyncdb::WaveSyncDb) -> Option<String> {
 async fn wait_for_seed(peer: &wavesyncdb::WaveSyncDb) {
     let deadline = Instant::now() + Duration::from_secs(20);
     loop {
-        if let Ok(Some(_)) = task::Entity::find_by_id(ROW_ID.to_string())
-            .one(peer)
-            .await
-        {
+        if let Ok(Some(_)) = task::Entity::find_by_id(ROW_ID.to_string()).one(peer).await {
             return;
         }
         if Instant::now() > deadline {

--- a/examples/bench/src/bin/bench_lan_sync.rs
+++ b/examples/bench/src/bin/bench_lan_sync.rs
@@ -78,9 +78,8 @@ async fn main() {
     let mut sorted = samples_us.clone();
     let p99 = percentile(&mut sorted, 99.0) as f64 / 1000.0;
     let max = samples_us.iter().copied().max().unwrap_or(0) as f64 / 1000.0;
-    let mean: f64 = samples_us.iter().map(|v| *v as f64).sum::<f64>()
-        / samples_us.len() as f64
-        / 1000.0;
+    let mean: f64 =
+        samples_us.iter().map(|v| *v as f64).sum::<f64>() / samples_us.len() as f64 / 1000.0;
 
     println!(
         "{:<10} {:>10} {:>10} {:>10} {:>10} {:>10}",

--- a/examples/qr_pairing/.env.example
+++ b/examples/qr_pairing/.env.example
@@ -1,0 +1,13 @@
+# Copy to `.env` (gitignored) and edit. Read at compile time by build.rs.
+#
+# Host the native app dials to reach `wavesync_relay`. Both desktop and
+# Android use this — the phone needs your dev machine's LAN IP if it's
+# a physical device on the same wifi as the relay. The web build
+# ignores this and uses `window.location.hostname` (i.e. whatever host
+# the browser loaded the page from).
+#
+# Defaults if unset:
+#   - desktop:           127.0.0.1
+#   - Android emulator:  10.0.2.2  (the emulator's loopback alias)
+#   - Android device:    you must set this — there is no good default
+WAVESYNC_RELAY_HOST=192.168.1.150

--- a/examples/qr_pairing/.gitignore
+++ b/examples/qr_pairing/.gitignore
@@ -1,0 +1,4 @@
+.test-logs/
+.test-pids/
+node_modules/
+package-lock.json

--- a/examples/qr_pairing/AndroidManifest.xml
+++ b/examples/qr_pairing/AndroidManifest.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Custom AndroidManifest for the qr_pairing example. This is a near-copy
+  of dx 0.7's bundled template (packages/cli/assets/android/gen/app/
+  src/main/AndroidManifest.xml.hbs) with our extras layered on top.
+  When `[application] android_manifest = "AndroidManifest.xml"` is set
+  in Dioxus.toml, dx replaces the template wholesale (no merge) — so
+  this file MUST keep every element the runtime needs:
+
+  - INTERNET permission (libp2p needs network)
+  - the activity meta-data entries (NativeActivity bridge)
+  - networkSecurityConfig="@xml/network_security_config" — dx generates
+    that XML resource into the project; without it referenced here the
+    WebView's HTTP-cleartext-to-localhost requests for the embedded
+    Dioxus assets get blocked on Android 9+ → blank/white screen with
+    no JS console output, exactly the failure mode the white-screen
+    bug had.
+-->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <uses-permission android:name="android.permission.INTERNET" />
+
+    <!-- QR pairing scanner — getUserMedia in the WebView. dx 0.7's
+         RustWebChromeClient handles the runtime permission grant on
+         Android, but only if the manifest declares the permission. -->
+    <uses-permission android:name="android.permission.CAMERA" />
+    <uses-feature android:name="android.hardware.camera" android:required="false" />
+    <uses-feature android:name="android.hardware.camera.autofocus" android:required="false" />
+
+    <application android:hasCode="true" android:icon="@mipmap/ic_launcher"
+        android:extractNativeLibs="true"
+        android:allowNativeHeapPointerTagging="false"
+        android:label="@string/app_name"
+        android:supportsRtl="true"
+        android:theme="@style/AppTheme"
+        android:networkSecurityConfig="@xml/network_security_config">
+        <activity
+            android:name="dev.dioxus.main.MainActivity"
+            android:exported="true"
+            android:label="@string/app_name"
+            android:configChanges="orientation|screenLayout|screenSize|keyboardHidden">
+            <meta-data android:name="android.app.lib_name" android:value="main" />
+            <meta-data android:name="android.app.func_name" android:value="ANativeActivity_onCreate" />
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
+</manifest>

--- a/examples/qr_pairing/Cargo.toml
+++ b/examples/qr_pairing/Cargo.toml
@@ -1,0 +1,60 @@
+[package]
+name = "example-qr-pairing"
+version = "0.1.0"
+edition = "2024"
+
+[[bin]]
+name = "qr-pairing"
+path = "src/main.rs"
+
+# Multi-target Dioxus example that builds for both web (wasm32) and
+# native (Android / desktop). Cargo's per-target dependency tables let
+# us pull SeaORM + sqlite-only on native, and pull the wasm32
+# equivalents (BrowserStore, qrcode renderer, browser bindings) only
+# when targeting the browser.
+[dependencies]
+dioxus = "0.7.6"
+serde = { workspace = true }
+serde_json = "1.0"
+log = { workspace = true }
+
+# Native (Android / iOS / desktop): full WaveSyncDb with SeaORM.
+# `derive` exposes the `#[derive(SyncEntity)]` macro the task entity
+# needs; `dioxus` brings in the reactive hooks (`use_synced_table`,
+# `use_wavesync`, etc).
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+wavesyncdb = { workspace = true, features = ["derive", "dioxus"] }
+sea-orm = { workspace = true }
+tokio = { workspace = true }
+env_logger = "0.11"
+uuid = { workspace = true }
+dioxus-sdk-storage = { git = "https://github.com/DioxusLabs/sdk.git" }
+
+# Android-only logging bridge. `env_logger` writes to stdout, which
+# Android `/dev/null`s for app processes — so without `android_logger`
+# every `log::*!` call disappears. We initialize it before anything
+# else in `native_app::run()` so panics + early errors actually land
+# in `adb logcat`.
+[target.'cfg(target_os = "android")'.dependencies]
+android_logger = "0.14"
+
+# Wasm32 (browser): WebSyncClient + IndexedDB + QR generator. No
+# SeaORM, no sqlx — those don't compile to wasm32. The example's web
+# task entity is a plain struct that `impl BrowserEntity` instead.
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+wavesyncdb = { workspace = true, features = ["web", "dioxus"] }
+# QR generator. Default `image` feature would pull in PNG encoding
+# we don't need — keep just `svg` for inline SVG rendering.
+qrcode = { version = "0.14", default-features = false, features = ["svg"] }
+getrandom = { version = "0.2", features = ["js"] }
+js-sys = "0.3"
+# `Location.hostname()` for the relay-default — the QR encodes the
+# host the browser is loading the page from, so a phone scanning it
+# from the same LAN reaches the relay without typing.
+web-sys = { version = "0.3", features = ["Window", "Location"] }
+# Bridge `log::*!` calls (the API wavesyncdb uses) to the browser
+# console. Dioxus's own logger captures only `tracing::*!` events;
+# without this, the engine's diagnostic `log::info!("WebSyncClient:
+# …")` lines never reach the Chrome devtools console — making it
+# impossible to debug from outside the running tab.
+wasm-logger = "0.2"

--- a/examples/qr_pairing/Dioxus.toml
+++ b/examples/qr_pairing/Dioxus.toml
@@ -1,0 +1,19 @@
+[application]
+name = "WaveSyncDB QR Pairing"
+default_platform = "web"
+
+# Custom AndroidManifest declares CAMERA permission for the QR
+# scanner. dx 0.7's bundled template doesn't include CAMERA — without
+# this override the WebView's getUserMedia request gets rejected at
+# the permission-grant step. Path-based; dx replaces the bundled
+# manifest wholesale (no merging).
+android_manifest = "AndroidManifest.xml"
+
+[android]
+min_sdk = 24
+target_sdk = 34
+identifier = "com.wavesync.qr_pairing"
+
+[web.app]
+title = "WaveSyncDB · QR Pairing"
+base_path = ""

--- a/examples/qr_pairing/build.rs
+++ b/examples/qr_pairing/build.rs
@@ -1,0 +1,48 @@
+//! Build script — loads `.env` from the example's root and re-exports
+//! its `KEY=VALUE` pairs as `cargo:rustc-env=KEY=VALUE`, so source can
+//! read them via `env!()` / `option_env!()` at compile time.
+//!
+//! Currently used for `WAVESYNC_RELAY_HOST`: the host the native app
+//! dials when reaching the relay. Defaults to `127.0.0.1` (desktop)
+//! and `10.0.2.2` (Android emulator) when unset; on a physical phone
+//! the user puts their dev machine's LAN IP in `.env`:
+//!
+//! ```
+//! WAVESYNC_RELAY_HOST=192.168.1.150
+//! ```
+//!
+//! Re-runs whenever `.env` changes or `WAVESYNC_RELAY_HOST` is set on
+//! the command line.
+
+use std::fs;
+use std::path::Path;
+
+fn main() {
+    let env_path = Path::new(".env");
+    println!("cargo:rerun-if-changed=.env");
+    println!("cargo:rerun-if-env-changed=WAVESYNC_RELAY_HOST");
+
+    let Ok(contents) = fs::read_to_string(env_path) else {
+        return;
+    };
+    for raw_line in contents.lines() {
+        let line = raw_line.trim();
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        let Some((key, value)) = line.split_once('=') else {
+            continue;
+        };
+        let key = key.trim();
+        let value = value
+            .trim()
+            .trim_start_matches('"')
+            .trim_end_matches('"')
+            .trim_start_matches('\'')
+            .trim_end_matches('\'');
+        if key.is_empty() {
+            continue;
+        }
+        println!("cargo:rustc-env={key}={value}");
+    }
+}

--- a/examples/qr_pairing/package.json
+++ b/examples/qr_pairing/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "qr_pairing",
+  "version": "1.0.0",
+  "description": "Single Cargo crate, two binaries:",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "devDependencies": {
+    "puppeteer-core": "^24.42.0"
+  }
+}

--- a/examples/qr_pairing/src/main.rs
+++ b/examples/qr_pairing/src/main.rs
@@ -1,0 +1,41 @@
+//! WaveSyncDB QR-pairing example — single crate, two binaries:
+//!
+//! - **Web build** (`dx serve --platform web`): renders a pairing
+//!   form, generates a `wavesync://?relay=…&topic=…&pass=…` QR, opens
+//!   a `WebSyncClient::connect_via_relay` to the same relay, and
+//!   shows a reactive task list.
+//! - **Native build** (`dx serve --platform android` / `desktop`):
+//!   on first launch shows a pairing screen with a "Pair via QR"
+//!   camera button (Android) and a manual form (any platform). Once
+//!   paired, builds a `WaveSyncDb` against the saved relay + topic +
+//!   passphrase and shows a reactive task list. Edits sync between
+//!   web and native through the relay.
+//!
+//! Run a `wavesync-relay` somewhere both peers can reach (LAN works
+//! for testing — the relay's `--ws-listen-addr` lets browsers join).
+//! Open the web build, fill in the relay address, generate the QR,
+//! scan it from the native build. Tasks added on either side sync.
+//!
+//! See `README.md` for the full end-to-end runbook.
+
+mod pairing;
+
+#[cfg(target_arch = "wasm32")]
+mod web_app;
+
+#[cfg(not(target_arch = "wasm32"))]
+mod native_app;
+#[cfg(not(target_arch = "wasm32"))]
+mod qr_scanner;
+#[cfg(not(target_arch = "wasm32"))]
+mod task_native;
+
+#[cfg(target_arch = "wasm32")]
+fn main() {
+    dioxus::launch(web_app::App);
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn main() {
+    native_app::run();
+}

--- a/examples/qr_pairing/src/native_app.rs
+++ b/examples/qr_pairing/src/native_app.rs
@@ -1,0 +1,753 @@
+//! Native side of the QR-pairing example.
+//!
+//! Two phases, both observed by the same `App` component via a
+//! `Signal<Option<WaveSyncDb>>`:
+//!
+//! 1. **Pairing** — when the signal is `None`, render the manual
+//!    pairing form plus, on Android, a "Pair via QR" button that
+//!    opens [`QrScannerOverlay`]. On save (manual or scan), the
+//!    pairing persists to `pairing.json` and a `WaveSyncDb` is built
+//!    asynchronously; once it's ready, the signal flips to `Some`.
+//! 2. **Task list** — when the signal is `Some(db)`, render the task
+//!    list inside a `Paired` child component that calls
+//!    `use_wavesync_provider(db)` so children's `use_wavesync()`
+//!    succeeds. Local edits flow through `submit_local_write`
+//!    (transparently via SeaORM); remote edits arrive through the
+//!    relay's circuit.
+//!
+//! No restart needed — the DB is constructed and torn down in-place
+//! from the running event loop. The "Re-pair" button replaces the
+//! signal with `None` after dropping the existing DB; the app
+//! transitions back to the pairing screen.
+
+use std::path::PathBuf;
+
+use dioxus::prelude::*;
+use sea_orm::{ActiveModelTrait, Set};
+use uuid::Uuid;
+use wavesyncdb::dioxus::{
+    use_network_status, use_synced_table, use_wavesync, use_wavesync_provider,
+};
+use wavesyncdb::{NatStatus, RelayStatus, WaveSyncDb, WaveSyncDbBuilder};
+
+use crate::pairing::{PairingParams, parse_pairing_url};
+// `QrScannerOverlay` only mounts on Android (the `render_scan_button`
+// helper is empty everywhere else, so `show_scanner` never flips to
+// true). The import + the `if show_scanner()` rsx line still need to
+// compile on non-Android targets where the overlay would never run —
+// that's fine, the type itself is `cfg`-agnostic in `qr_scanner.rs`.
+#[allow(unused_imports)]
+use crate::qr_scanner::QrScannerOverlay;
+use crate::task_native as task;
+
+/// Relay host — invisible plumbing, not part of the pairing payload.
+/// Resolution order, picked at compile time:
+///
+/// 1. **`WAVESYNC_RELAY_HOST` from `.env`** (or shell env) — set by
+///    `build.rs`. Use this on a physical Android device, where
+///    neither default below is reachable. See `.env.example`.
+/// 2. **`10.0.2.2`** on Android — the emulator-provided alias for
+///    the dev machine's loopback. Doesn't resolve on real devices.
+/// 3. **`127.0.0.1`** elsewhere (desktop running on the same machine
+///    as the relay).
+///
+/// **Native libp2p in this crate uses QUIC only** (see
+/// `wavesyncdb/src/engine/mod.rs::build_swarm` — `.with_quic()` and
+/// no `.with_tcp()`, deliberate for cold-start latency + to avoid
+/// double connections per peer when both transports race). So we
+/// dial the relay's `/udp/4001/quic-v1` listener — *not* `/tcp/4001`
+/// (which would error out as `Unsupported resolved address`) and
+/// *not* `/tcp/4002/ws` (no WebSocket transport on native). The web
+/// build hits the same relay via its `/ws` listener.
+const RELAY_HOST: &str = match option_env!("WAVESYNC_RELAY_HOST") {
+    Some(h) => h,
+    None => DEFAULT_RELAY_HOST,
+};
+
+#[cfg(target_os = "android")]
+const DEFAULT_RELAY_HOST: &str = "10.0.2.2";
+#[cfg(not(target_os = "android"))]
+const DEFAULT_RELAY_HOST: &str = "127.0.0.1";
+
+const RELAY_PEER_ID: &str = "12D3KooWP6oyorVZmZvTRPHdxsEyE2V8mR1dTiAZJYoNsMNX19KW";
+
+fn relay_multiaddr() -> String {
+    format!("/ip4/{RELAY_HOST}/udp/4001/quic-v1/p2p/{RELAY_PEER_ID}")
+}
+
+const DEFAULT_TOPIC: &str = "qr-pairing-demo";
+const DEFAULT_PASS: &str = "demo-shared-secret";
+
+/// Path of the persisted pairing JSON. Sits next to the SQLite database
+/// in `data_directory()`. Schema is `{peer, topic, pass}` — the relay
+/// is hardcoded per-platform, not persisted. Absent file (or a file
+/// missing `peer`/`topic`) means "not paired yet — show the pairing
+/// form". Old `{relay, topic, pass}` files written by previous
+/// versions of this example fall through that check, so the user
+/// re-pairs once.
+fn pairing_path() -> PathBuf {
+    dioxus_sdk_storage::data_directory().join("qr-pairing.json")
+}
+
+fn read_pairing() -> Option<PairingParams> {
+    let raw = std::fs::read_to_string(pairing_path()).ok()?;
+    let v: serde_json::Value = serde_json::from_str(&raw).ok()?;
+    Some(PairingParams {
+        peer_id: v.get("peer")?.as_str()?.to_string(),
+        topic: v.get("topic")?.as_str()?.to_string(),
+        pass: v
+            .get("pass")
+            .and_then(|p| p.as_str())
+            .map(str::to_string)
+            .filter(|s| !s.is_empty()),
+    })
+}
+
+fn write_pairing(p: &PairingParams) -> std::io::Result<()> {
+    let path = pairing_path();
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let v = serde_json::json!({
+        "peer": p.peer_id,
+        "topic": p.topic,
+        "pass": p.pass.clone().unwrap_or_default(),
+    });
+    std::fs::write(path, serde_json::to_string_pretty(&v)?)
+}
+
+pub fn run() {
+    // ── logging ───────────────────────────────────────────────
+    // Android `/dev/null`s app stdout, so `env_logger` writes
+    // nowhere on a phone. `android_logger` routes `log::*!` calls
+    // into `adb logcat` under the tag below. Desktop/iOS keep using
+    // `env_logger`. Initialize this BEFORE anything else so panics
+    // and early init errors reach the logger we're about to install.
+    init_logger();
+
+    // Panic hook that logs the panic + backtrace before the default
+    // hook tears the process down. Without this, an early panic on
+    // Android shows up as "process died" in logcat with no
+    // diagnostic — exactly the white-screen-no-logs failure mode.
+    std::panic::set_hook(Box::new(|info| {
+        log::error!("PANIC: {info}");
+        eprintln!("PANIC: {info}");
+    }));
+
+    // Quiet libp2p / sqlx with the recommended log filters so the
+    // example output is readable.
+    if std::env::var_os("RUST_LOG").is_none() {
+        let directives: Vec<String> = std::iter::once("info".to_string())
+            .chain(
+                wavesyncdb::recommended_log_filters()
+                    .into_iter()
+                    .map(|(m, lvl)| format!("{m}={}", lvl.as_str().to_lowercase())),
+            )
+            .collect();
+        // SAFETY: setting an env var before threads start is sound;
+        // this runs on the main thread before tokio spawns anything.
+        unsafe {
+            std::env::set_var("RUST_LOG", directives.join(","));
+        }
+    }
+
+    log::info!("qr-pairing: native run() entered");
+
+    // Build the runtime up-front and `enter()` so the guard lives for
+    // the whole `dioxus::launch` call. Inside Dioxus components,
+    // `spawn(async move { … })` then resolves `.await`s against this
+    // runtime — that's how the reactive DB build below works.
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .expect("Failed to create tokio runtime");
+    let _guard = rt.enter();
+    log::info!("qr-pairing: tokio runtime ready");
+    log::info!("qr-pairing: launching Dioxus");
+    dioxus::launch(App);
+}
+
+/// Build a `WaveSyncDb` against the supplied pairing. Async so it
+/// can be awaited from a `spawn` inside a Dioxus event handler — that's
+/// what lets the UI flip from "pairing screen" to "task list" without
+/// restarting the app.
+async fn build_db(paired: PairingParams) -> Result<WaveSyncDb, String> {
+    let data_directory = dioxus_sdk_storage::data_directory().join("qr-pairing.db");
+    if let Some(parent) = data_directory.parent() {
+        if let Err(e) = std::fs::create_dir_all(parent) {
+            return Err(format!("create data dir: {e}"));
+        }
+    }
+
+    // Relay is plumbing — not part of the pairing payload. Both web
+    // and native dial the same logical relay; only the transport
+    // differs (web = `/tcp/4002/ws`, native = `/tcp/4001`). The QR
+    // carries `peer_id` (which web peer to display + verify against
+    // the topic mesh) plus `topic` + `pass` (per-session sync mesh).
+    let relay = relay_multiaddr();
+    log::info!(
+        "qr-pairing: relay={relay} pairing-with-peer={}",
+        paired.peer_id
+    );
+
+    let mut builder = WaveSyncDbBuilder::new(
+        &format!("sqlite:{}?mode=rwc", data_directory.display()),
+        &paired.topic,
+    )
+    .with_relay_server(&relay);
+    if let Some(pass) = paired.pass.as_deref() {
+        builder = builder.with_passphrase(pass);
+    }
+
+    log::info!("qr-pairing: building WaveSyncDb…");
+    let db = builder.build().await.map_err(|e| format!("build: {e}"))?;
+    log::info!("qr-pairing: schema sync…");
+    db.get_schema_registry(module_path!().split("::").next().unwrap())
+        .sync()
+        .await
+        .map_err(|e| format!("schema sync: {e}"))?;
+    log::info!("qr-pairing: WaveSyncDb ready");
+    Ok(db)
+}
+
+/// Init the right log backend per target. On Android, route to
+/// `adb logcat` via `android_logger`; everywhere else, use the
+/// standard `env_logger` (writes to stdout). Both honor `RUST_LOG`,
+/// so the same module-level filter recipe works on every platform.
+fn init_logger() {
+    #[cfg(target_os = "android")]
+    {
+        use android_logger::{Config, FilterBuilder};
+        let mut filter = FilterBuilder::new();
+        filter.filter_level(log::LevelFilter::Info);
+        // Same noise reduction the env_logger path applies — keep
+        // the libp2p / sqlx output below `info` so logcat is
+        // readable while debugging the demo.
+        for (module, level) in wavesyncdb::recommended_log_filters() {
+            filter.filter_module(module, level);
+        }
+        android_logger::init_once(
+            Config::default()
+                .with_max_level(log::LevelFilter::Trace)
+                .with_tag("WaveSyncDB")
+                .with_filter(filter.build()),
+        );
+    }
+    #[cfg(not(target_os = "android"))]
+    {
+        let mut log_builder =
+            env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info"));
+        for (module, level) in wavesyncdb::recommended_log_filters() {
+            log_builder.filter_module(module, level);
+        }
+        let _ = log_builder.try_init();
+    }
+}
+
+#[allow(non_snake_case)]
+fn App() -> Element {
+    // Single source of truth for "is the DB ready?" Signal-driven so
+    // both first-launch (we read pairing.json on mount and build) and
+    // post-pairing (the form's `on_paired` callback builds) flow
+    // through the same path.
+    let mut db_signal = use_signal(|| None::<WaveSyncDb>);
+    let mut build_error = use_signal(|| Option::<String>::None);
+    let mut building = use_signal(|| false);
+
+    // Closure that takes a `PairingParams`, persists it, and triggers
+    // an async build of the WaveSyncDb. On success, db_signal flips
+    // to Some and the App branches into the Paired view. Reused by
+    // first-launch auto-connect and post-pairing save.
+    let mut build_for = move |paired: PairingParams| {
+        if *building.read() {
+            return;
+        }
+        building.set(true);
+        build_error.set(None);
+        spawn(async move {
+            match build_db(paired).await {
+                Ok(db) => db_signal.set(Some(db)),
+                Err(e) => {
+                    log::warn!("qr-pairing: build_db failed: {e}");
+                    build_error.set(Some(e));
+                }
+            }
+            building.set(false);
+        });
+    };
+
+    // First mount: if pairing.json exists, kick off an async build so
+    // the UI flips to Paired without user interaction. `use_hook` runs
+    // exactly once for the component's lifetime; using `use_effect`
+    // here would re-trigger every time we set db_signal/build_error
+    // and produce a build loop.
+    use_hook(move || {
+        if let Some(paired) = read_pairing() {
+            log::info!("qr-pairing: pairing.json present, auto-building DB");
+            build_for(paired);
+        } else {
+            log::info!("qr-pairing: no pairing.json, showing pairing screen");
+        }
+    });
+
+    rsx! {
+        style { {STYLE} }
+        div { class: "app",
+            h1 { "WaveSyncDB · QR pairing" }
+            if let Some(db) = db_signal() {
+                Paired { db, db_signal }
+            } else {
+                PairingScreen {
+                    building: building(),
+                    error: build_error(),
+                    on_paired: move |p| build_for(p),
+                }
+            }
+        }
+    }
+}
+
+/// Wraps the task-list views in a child component so
+/// `use_wavesync_provider` is called consistently — Dioxus hook rules
+/// require a stable hook order per component, so we can't call the
+/// provider conditionally inside `App`'s rsx.
+#[component]
+fn Paired(db: WaveSyncDb, db_signal: Signal<Option<WaveSyncDb>>) -> Element {
+    use_wavesync_provider(db);
+    rsx! {
+        PairedHeader { db_signal }
+        DebugPanel {}
+        AddTaskForm {}
+        TaskList {}
+    }
+}
+
+/// Live network state from `use_network_status`. Gives an at-a-glance
+/// answer to "is the relay reachable, do we see peers, are we behind
+/// NAT, what's our db_version, what peer-id are we presenting on the
+/// wire." All values come from the engine's `NetworkStatus` snapshot,
+/// updated on every relay/peer state change.
+#[component]
+fn DebugPanel() -> Element {
+    let db = use_wavesync();
+    let status = use_network_status(db);
+
+    let s = status();
+    let relay_class = match s.relay_status {
+        RelayStatus::Listening => "value online",
+        RelayStatus::Connected => "value pending",
+        RelayStatus::Connecting => "value pending",
+        RelayStatus::Disabled => "value offline",
+    };
+    let nat_label = match s.nat_status {
+        NatStatus::Public => "Public",
+        NatStatus::Private => "Private (NAT'd)",
+        NatStatus::Unknown => "Unknown",
+    };
+    let peer_count = s.connected_peers.len();
+    let group_count = s.group_peer_count();
+
+    rsx! {
+        div { class: "panel",
+            h2 { "Network" }
+            p { class: "kv", strong { "Local peer-id " }
+                code { class: "wrap", "{s.local_peer_id}" }
+            }
+            p { class: "kv", strong { "Relay " }
+                span { class: "{relay_class}", "{s.relay_status:?}" }
+            }
+            p { class: "kv", strong { "NAT " } "{nat_label}" }
+            p { class: "kv", strong { "Topic " } code { "{s.topic}" } }
+            p { class: "kv", strong { "Local db_version " } "{s.local_db_version}" }
+            p { class: "kv", strong { "Peers " }
+                span { class: if peer_count > 0 { "value online" } else { "value offline" },
+                    "{peer_count} connected · {group_count} in group"
+                }
+            }
+
+            // Per-peer detail. Group peers (same topic + passphrase)
+            // get a "group" badge; bootstrap/relay peers are listed
+            // but tagged so it's obvious they're plumbing, not data
+            // partners.
+            if !s.connected_peers.is_empty() {
+                ul { class: "peer-list",
+                    for peer in s.connected_peers.iter() {
+                        li {
+                            key: "{peer.peer_id}",
+                            class: "peer",
+                            div { class: "peer-id",
+                                code { "{peer.peer_id}" }
+                                if peer.is_group_member {
+                                    span { class: "peer-badge group", "group" }
+                                }
+                                if peer.is_bootstrap {
+                                    span { class: "peer-badge relay", "relay" }
+                                }
+                            }
+                            div { class: "peer-meta",
+                                span { class: "peer-addr", "{peer.address}" }
+                                if let Some(v) = peer.db_version {
+                                    span { class: "peer-version", "db_version={v}" }
+                                } else {
+                                    span { class: "peer-version", "db_version=?" }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[component]
+fn PairingScreen(
+    /// `true` while the parent is asynchronously building the
+    /// `WaveSyncDb`. The form disables Save while in flight to avoid
+    /// double-submits.
+    building: bool,
+    /// Surfaced from the parent's `build_db` future when it errors —
+    /// e.g., relay unreachable, sqlite path bad.
+    error: Option<String>,
+    /// Fired when the user completes the form (manual save or QR
+    /// scan). Parent persists the pairing and triggers `build_db`.
+    on_paired: EventHandler<PairingParams>,
+) -> Element {
+    let mut peer_id_in = use_signal(String::new);
+    let mut topic = use_signal(|| DEFAULT_TOPIC.to_string());
+    let mut pass = use_signal(|| DEFAULT_PASS.to_string());
+    let mut show_scanner = use_signal(|| false);
+    let mut local_err = use_signal(|| Option::<String>::None);
+
+    let mut submit_pairing = move |p: PairingParams| {
+        // Persist for next launch even though we don't strictly need
+        // restart anymore — keeps the saved-pairing path working when
+        // the user kills + reopens.
+        if let Err(e) = write_pairing(&p) {
+            local_err.set(Some(format!("Failed to write pairing.json: {e}")));
+            return;
+        }
+        local_err.set(None);
+        on_paired.call(p);
+    };
+
+    let on_manual_save = move |_| {
+        let pid = peer_id_in().trim().to_string();
+        let t = topic().trim().to_string();
+        if pid.is_empty() || t.is_empty() {
+            local_err.set(Some("Web peer-id and topic are required.".into()));
+            return;
+        }
+        let p = pass();
+        let p_opt = if p.is_empty() { None } else { Some(p) };
+        submit_pairing(PairingParams {
+            peer_id: pid,
+            topic: t,
+            pass: p_opt,
+        });
+    };
+
+    let mut on_scan_detect = move |raw: String| {
+        show_scanner.set(false);
+        match parse_pairing_url(&raw) {
+            Some(p) => submit_pairing(p),
+            None => local_err.set(Some(format!(
+                "Scanned QR isn't a wavesync:// pairing URL: {raw}"
+            ))),
+        }
+    };
+
+    rsx! {
+        div { class: "panel",
+            h2 { "Pair this device" }
+            p { class: "blurb",
+                "Scan the QR shown by the web build, or paste the web peer-id and "
+                "topic by hand. The relay is hardcoded into this app — see "
+                "src/native_app.rs RELAY_HOST."
+            }
+            p { class: "kv", strong { "Relay " } code { "{relay_multiaddr()}" } }
+            // Real-device hint. `#[cfg]` inside rsx isn't legal, so
+            // factor the Android-only banner into a helper that's
+            // defined twice (Android = real banner, others = empty).
+            { render_real_device_hint() }
+
+            // `#[cfg]` attributes inside rsx aren't legal — hand off
+            // to a helper that's defined twice (Android = real button,
+            // others = empty).
+            { render_scan_button(show_scanner) }
+
+            label { "Web peer-id" }
+            input {
+                r#type: "text",
+                placeholder: "12D3KooW…",
+                value: "{peer_id_in}",
+                oninput: move |e| peer_id_in.set(e.value()),
+                disabled: building,
+            }
+            label { "Topic" }
+            input {
+                r#type: "text",
+                value: "{topic}",
+                oninput: move |e| topic.set(e.value()),
+                disabled: building,
+            }
+            label { "Passphrase (optional)" }
+            input {
+                r#type: "password",
+                value: "{pass}",
+                oninput: move |e| pass.set(e.value()),
+                disabled: building,
+            }
+            button {
+                class: "primary",
+                onclick: on_manual_save,
+                disabled: building,
+                if building { "Connecting…" } else { "Connect" }
+            }
+
+            if let Some(err) = local_err() {
+                div { class: "error", "{err}" }
+            }
+            if let Some(err) = error.clone() {
+                div { class: "error", "Build failed: {err}" }
+            }
+        }
+
+        if show_scanner() {
+            QrScannerOverlay {
+                on_detect: move |raw| on_scan_detect(raw),
+                on_close: move |_| show_scanner.set(false),
+            }
+        }
+    }
+}
+
+#[component]
+fn PairedHeader(mut db_signal: Signal<Option<WaveSyncDb>>) -> Element {
+    let paired = read_pairing();
+    let mut clear_msg = use_signal(|| Option::<String>::None);
+
+    let do_clear = move |_| {
+        // Drop the DB by flipping the signal to None — `Paired` stops
+        // rendering, the engine task and SQLite pool drop, the App
+        // re-renders the pairing form. No restart.
+        db_signal.set(None);
+        match std::fs::remove_file(pairing_path()) {
+            Ok(()) => clear_msg.set(None),
+            Err(e) => clear_msg.set(Some(format!("Failed to clear pairing.json: {e}"))),
+        }
+    };
+
+    rsx! {
+        div { class: "panel",
+            h2 { "Connected" }
+            if let Some(p) = paired {
+                p { class: "kv", strong { "Topic " } "{p.topic}" }
+                p { class: "kv", strong { "Paired with " } code { class: "wrap", "{p.peer_id}" } }
+                p { class: "kv", strong { "Relay " } code { "{relay_multiaddr()}" } }
+                p { class: "kv", strong { "Passphrase " }
+                    if p.pass.is_some() { "(set)" } else { "(none)" }
+                }
+            }
+            button { class: "secondary", onclick: do_clear, "Re-pair" }
+            if let Some(msg) = clear_msg() {
+                div { class: "notice", "{msg}" }
+            }
+        }
+    }
+}
+
+#[component]
+fn AddTaskForm() -> Element {
+    let db = use_wavesync();
+    let mut title = use_signal(String::new);
+
+    // `Callback` is `Copy`, so the same handler can be captured by
+    // both the click and keydown closures without dancing around the
+    // borrow checker (a plain `move ||` closure that mutates `title`
+    // can only be moved into one place).
+    let do_add = use_callback(move |_: ()| {
+        let t = title().trim().to_string();
+        if t.is_empty() {
+            return;
+        }
+        title.set(String::new());
+        let db = db.clone();
+        spawn(async move {
+            let now = chrono_now_ms();
+            let task = task::ActiveModel {
+                id: Set(Uuid::new_v4().to_string()),
+                title: Set(t),
+                done: Set(false),
+                created_at: Set(now),
+            };
+            // SeaORM insert flows through wavesyncdb's interception
+            // layer — the row commits to local SQLite AND fans out to
+            // peers via the snapshot push protocol. No extra wiring.
+            let _ = task.insert(&db).await;
+        });
+    });
+
+    rsx! {
+        div { class: "panel",
+            h2 { "Add a task" }
+            div { class: "add-row",
+                input {
+                    placeholder: "What needs to be done?",
+                    value: "{title}",
+                    oninput: move |e| title.set(e.value()),
+                    onkeydown: move |e| { if e.key() == Key::Enter { do_add(()); } },
+                }
+                button {
+                    class: "primary",
+                    onclick: move |_| do_add(()),
+                    "Add"
+                }
+            }
+        }
+    }
+}
+
+#[component]
+fn TaskList() -> Element {
+    let db = use_wavesync();
+    // `use_synced_table` consumes the db value; clone first so we can
+    // still hand it to the per-task toggle handlers below.
+    let tasks = use_synced_table::<task::Entity>(db.clone());
+
+    let mut visible: Vec<task::Model> = tasks().clone();
+    visible.sort_by_key(|t| std::cmp::Reverse(t.created_at));
+
+    rsx! {
+        div { class: "panel",
+            h2 { "Tasks" }
+            ul { class: "task-list",
+                if visible.is_empty() {
+                    li { class: "empty", "No tasks yet — add one or wait for a peer." }
+                }
+                for t in visible.into_iter() {
+                    {
+                        let db = db.clone();
+                        let t_for_toggle = t.clone();
+                        rsx! {
+                            li {
+                                key: "{t.id}",
+                                class: if t.done { "task done" } else { "task" },
+                                input {
+                                    r#type: "checkbox",
+                                    checked: t.done,
+                                    onchange: move |_| {
+                                        let db = db.clone();
+                                        let t = t_for_toggle.clone();
+                                        spawn(async move {
+                                            let mut am: task::ActiveModel = t.into();
+                                            am.done = Set(!*am.done.as_ref());
+                                            let _ = am.update(&db).await;
+                                        });
+                                    },
+                                }
+                                span { class: "title", "{t.title}" }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn chrono_now_ms() -> i64 {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as i64)
+        .unwrap_or(0)
+}
+
+// Camera-based QR scanning is Android-only in this example: dx 0.7's
+// `RustWebChromeClient` only handles the runtime CAMERA permission
+// flow on Android, and desktop has no camera worth pointing at the
+// browser's QR anyway. iOS would need extra Info.plist entries this
+// example doesn't ship. Two definitions of `render_scan_button` —
+// the Android one renders the real button, others render nothing —
+// keep the call site in `PairingScreen` clean.
+#[cfg(target_os = "android")]
+fn render_scan_button(mut show_scanner: Signal<bool>) -> Element {
+    rsx! {
+        button {
+            class: "primary",
+            onclick: move |_| show_scanner.set(true),
+            "📷 Scan pairing QR"
+        }
+    }
+}
+
+#[cfg(not(target_os = "android"))]
+fn render_scan_button(_show_scanner: Signal<bool>) -> Element {
+    rsx! {}
+}
+
+/// Android-only banner that warns about the `10.0.2.2` emulator
+/// default not working on physical devices and points at the QR-scan
+/// workflow as the fix. Two definitions for the same reason as
+/// `render_scan_button`.
+#[cfg(target_os = "android")]
+fn render_real_device_hint() -> Element {
+    rsx! {
+        p { class: "hint",
+            "Relay host baked in at compile time: "
+            code { "{RELAY_HOST}" }
+            ". On a physical phone, set "
+            code { "WAVESYNC_RELAY_HOST=<your LAN IP>" }
+            " in "
+            code { ".env" }
+            " (see .env.example) and rebuild."
+        }
+    }
+}
+
+#[cfg(not(target_os = "android"))]
+fn render_real_device_hint() -> Element {
+    rsx! {}
+}
+
+const STYLE: &str = r#"
+body { background: #0a0d12; color: #e6ecf2; font-family: -apple-system, BlinkMacSystemFont, "Inter", "Segoe UI", Roboto, sans-serif; margin: 0; }
+.app { max-width: 640px; margin: 0 auto; padding: 24px 16px 48px; }
+.app h1 { font-size: 1.5rem; margin: 0 0 16px; }
+.panel { background: #11151c; border: 1px solid #232a36; border-radius: 12px; padding: 18px; margin-bottom: 16px; }
+.panel h2 { margin: 0 0 12px; font-size: 1rem; text-transform: uppercase; letter-spacing: 0.5px; color: #9aa6b6; }
+.blurb { color: #9aa6b6; line-height: 1.5; margin: 0 0 14px; font-size: 0.9rem; }
+.panel label { display: block; color: #9aa6b6; font-size: 0.72rem; text-transform: uppercase; letter-spacing: 0.5px; margin-top: 12px; margin-bottom: 4px; }
+.panel input[type="text"], .panel input[type="password"] { width: 100%; padding: 10px 12px; background: #0a0d12; border: 1px solid #303949; border-radius: 6px; color: #e6ecf2; font-family: ui-monospace, "SF Mono", Menlo, monospace; font-size: 0.9rem; box-sizing: border-box; }
+button.primary { margin-top: 12px; padding: 10px 18px; background: #6ce0c9; color: #06231f; border: none; border-radius: 6px; font-weight: 600; cursor: pointer; font-size: 0.95rem; }
+button.secondary { margin-top: 8px; padding: 8px 14px; background: transparent; color: #9aa6b6; border: 1px solid #303949; border-radius: 6px; cursor: pointer; font-size: 0.85rem; }
+.error { margin-top: 12px; padding: 10px; background: rgba(247, 200, 124, 0.08); border: 1px solid #f7c87c; color: #f7c87c; border-radius: 6px; font-size: 0.85rem; }
+.notice { margin-top: 12px; padding: 10px; background: rgba(108, 224, 201, 0.08); border: 1px solid #6ce0c9; color: #6ce0c9; border-radius: 6px; font-size: 0.85rem; }
+.hint { font-size: 0.78rem; color: #f7c87c; background: rgba(247, 200, 124, 0.06); border: 1px solid rgba(247, 200, 124, 0.3); padding: 8px 10px; border-radius: 6px; margin: 0 0 12px; line-height: 1.4; }
+.hint code { background: rgba(0, 0, 0, 0.3); padding: 1px 4px; border-radius: 3px; font-size: 0.85em; }
+.add-row { display: flex; gap: 8px; }
+.add-row input { flex: 1; padding: 9px 12px; background: #0a0d12; border: 1px solid #303949; border-radius: 6px; color: #e6ecf2; font-size: 0.95rem; }
+.add-row button.primary { margin-top: 0; }
+.task-list { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 6px; }
+.task { display: flex; align-items: center; gap: 12px; padding: 10px 12px; background: #0a0d12; border: 1px solid #232a36; border-radius: 6px; }
+.task.done .title { text-decoration: line-through; color: #6f7c8e; }
+.task input[type="checkbox"] { accent-color: #6ce0c9; width: 17px; height: 17px; cursor: pointer; }
+.empty { text-align: center; color: #6f7c8e; font-style: italic; padding: 16px; }
+.kv { font-size: 0.85rem; color: #e6ecf2; margin: 4px 0; }
+.kv strong { color: #9aa6b6; font-weight: 500; margin-right: 6px; }
+.kv code { font-size: 0.8rem; word-break: break-all; }
+.kv code.wrap { word-break: break-all; display: inline-block; max-width: 100%; }
+.value.online { color: #6ce0c9; }
+.value.offline { color: #e74c3c; }
+.value.pending { color: #f39c12; }
+.peer-list { list-style: none; margin: 12px 0 0; padding: 0; display: flex; flex-direction: column; gap: 8px; }
+.peer { padding: 10px 12px; background: #0a0d12; border: 1px solid #232a36; border-radius: 6px; }
+.peer-id { display: flex; flex-wrap: wrap; align-items: center; gap: 6px; }
+.peer-id code { font-size: 0.75rem; word-break: break-all; flex: 1; min-width: 0; }
+.peer-badge { font-size: 0.65rem; text-transform: uppercase; letter-spacing: 0.5px; padding: 2px 6px; border-radius: 4px; flex-shrink: 0; }
+.peer-badge.group { background: rgba(108, 224, 201, 0.15); color: #6ce0c9; }
+.peer-badge.relay { background: rgba(124, 159, 247, 0.15); color: #7c9ff7; }
+.peer-meta { display: flex; gap: 8px; font-family: ui-monospace, "SF Mono", Menlo, monospace; font-size: 0.7rem; color: #6f7c8e; margin-top: 4px; word-break: break-all; }
+.peer-version { color: #9aa6b6; }
+"#;

--- a/examples/qr_pairing/src/pairing.rs
+++ b/examples/qr_pairing/src/pairing.rs
@@ -1,0 +1,201 @@
+//! Shared pairing-URL helpers.
+//!
+//! The pairing protocol is a URL of the form
+//! `wavesync://?peer=<urlenc>&topic=<urlenc>&pass=<urlenc>` — the
+//! browser side encodes one and renders it as a QR; the phone side
+//! scans the QR, gets the same URL string back from
+//! `BarcodeDetector`, and parses it here to recover the peer + topic +
+//! passphrase the web is announcing on. Compiles on every target.
+//!
+//! The relay multiaddr is **not** in the QR. Both apps hard-code it
+//! per-platform (web uses `/ws`, native uses `/tcp/4001`), since
+//! that's invisible plumbing — the user thinks of "pairing my phone"
+//! as exchanging an identity, not a server address.
+
+/// Decoded pairing parameters scanned from a QR (or pasted from a
+/// URL). `pass = None` means "no passphrase configured", same
+/// convention `WebSyncClient::connect_via_relay` and
+/// `WaveSyncDbBuilder::with_passphrase` use.
+///
+/// `peer_id` is the libp2p PeerId of the *web* peer (string form,
+/// e.g. `12D3KooW…`) — encoded so the phone can display "paired with
+/// X" and verify a peer it sees on the relay's topic mesh is the one
+/// it scanned.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PairingParams {
+    pub peer_id: String,
+    pub topic: String,
+    pub pass: Option<String>,
+}
+
+/// Build the `wavesync://?peer=…&topic=…&pass=…` URL the browser
+/// renders into a QR. Used on the web side; the parse function below
+/// is the inverse, used on the phone side.
+///
+/// `#[allow(dead_code)]` because only the wasm32 path constructs URLs
+/// — native parses them. Stripping the `cfg(...)`-gating keeps the
+/// roundtrip test in this module compilable on every target.
+#[allow(dead_code)]
+pub fn build_pairing_url(p: &PairingParams) -> String {
+    match &p.pass {
+        Some(pass) if !pass.is_empty() => format!(
+            "wavesync://?peer={}&topic={}&pass={}",
+            percent_encode(&p.peer_id),
+            percent_encode(&p.topic),
+            percent_encode(pass),
+        ),
+        _ => format!(
+            "wavesync://?peer={}&topic={}",
+            percent_encode(&p.peer_id),
+            percent_encode(&p.topic),
+        ),
+    }
+}
+
+/// Parse a pairing URL.
+///
+/// Lenient about scheme — accepts both `wavesync://` and `wavesync:`
+/// prefixes; also accepts a bare query string so a user can paste
+/// just the params if QR scanning fails. Returns `None` if `peer` or
+/// `topic` is missing — those two are required.
+///
+/// `#[allow(dead_code)]` because only the native path scans QRs and
+/// parses URLs — the wasm path constructs them. Kept module-public
+/// (and target-agnostic) so the test below can exercise it on every
+/// target without cfg gymnastics.
+#[allow(dead_code)]
+pub fn parse_pairing_url(raw: &str) -> Option<PairingParams> {
+    let after_scheme = raw
+        .strip_prefix("wavesync://")
+        .or_else(|| raw.strip_prefix("wavesync:"))
+        .unwrap_or(raw);
+    let query = after_scheme
+        .split_once('?')
+        .map(|(_, q)| q)
+        .unwrap_or(after_scheme);
+
+    let mut peer_id = None;
+    let mut topic = None;
+    let mut pass = None;
+    for kv in query.split('&') {
+        let Some((k, v)) = kv.split_once('=') else {
+            continue;
+        };
+        let v = percent_decode(v);
+        match k {
+            "peer" => peer_id = Some(v),
+            "topic" => topic = Some(v),
+            "pass" => pass = Some(v),
+            _ => {}
+        }
+    }
+    Some(PairingParams {
+        peer_id: peer_id?,
+        topic: topic?,
+        pass: pass.filter(|s| !s.is_empty()),
+    })
+}
+
+/// Tiny percent-encoder for the pairing-URL query params. Encodes
+/// anything that isn't an unreserved character per RFC 3986. Adding
+/// a `urlencoding` crate just for this would be overkill — we
+/// control both ends and inputs are short.
+#[allow(dead_code)]
+fn percent_encode(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for b in s.as_bytes() {
+        match b {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
+                out.push(*b as char);
+            }
+            _ => out.push_str(&format!("%{:02X}", b)),
+        }
+    }
+    out
+}
+
+/// Decode a percent-encoded value. Tolerant — unrecognized escapes
+/// are left as-is rather than failing the whole parse, so a
+/// hand-typed URL with one bad escape still produces something
+/// readable rather than `None`.
+#[allow(dead_code)]
+fn percent_decode(s: &str) -> String {
+    let bytes = s.as_bytes();
+    let mut out = Vec::with_capacity(bytes.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        match bytes[i] {
+            b'%' if i + 2 < bytes.len() => {
+                let hi = hex(bytes[i + 1]);
+                let lo = hex(bytes[i + 2]);
+                if let (Some(h), Some(l)) = (hi, lo) {
+                    out.push((h << 4) | l);
+                    i += 3;
+                    continue;
+                }
+                out.push(bytes[i]);
+                i += 1;
+            }
+            b'+' => {
+                out.push(b' ');
+                i += 1;
+            }
+            b => {
+                out.push(b);
+                i += 1;
+            }
+        }
+    }
+    String::from_utf8(out).unwrap_or_default()
+}
+
+#[allow(dead_code)]
+fn hex(b: u8) -> Option<u8> {
+    match b {
+        b'0'..=b'9' => Some(b - b'0'),
+        b'a'..=b'f' => Some(b - b'a' + 10),
+        b'A'..=b'F' => Some(b - b'A' + 10),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn url_roundtrip() {
+        let p = PairingParams {
+            peer_id: "12D3KooWP6oyorVZmZvTRPHdxsEyE2V8mR1dTiAZJYoNsMNX19KW".into(),
+            topic: "demo".into(),
+            pass: Some("hunter 2".into()),
+        };
+        let url = build_pairing_url(&p);
+        let parsed = parse_pairing_url(&url).unwrap();
+        assert_eq!(parsed, p);
+    }
+
+    #[test]
+    fn no_passphrase() {
+        let p = parse_pairing_url("wavesync://?peer=abcDEF&topic=bar").unwrap();
+        assert_eq!(p.peer_id, "abcDEF");
+        assert_eq!(p.topic, "bar");
+        assert_eq!(p.pass, None);
+    }
+
+    #[test]
+    fn empty_passphrase_yields_none() {
+        let p = parse_pairing_url("wavesync://?peer=abcDEF&topic=bar&pass=").unwrap();
+        assert_eq!(p.pass, None);
+    }
+
+    #[test]
+    fn missing_peer_returns_none() {
+        assert!(parse_pairing_url("wavesync://?topic=bar").is_none());
+    }
+
+    #[test]
+    fn missing_topic_returns_none() {
+        assert!(parse_pairing_url("wavesync://?peer=abcDEF").is_none());
+    }
+}

--- a/examples/qr_pairing/src/qr_scanner.rs
+++ b/examples/qr_pairing/src/qr_scanner.rs
@@ -1,0 +1,269 @@
+//! Camera-based QR-code scanner. Mounted as a full-screen overlay
+//! when the user taps "Pair via QR" on Android. Mirrors the pattern
+//! from MediterraneaDiente's barcode scanner — same `BarcodeDetector`
+//! polling, same `dioxus.send` IPC for messages back to Rust, same
+//! `use_drop` cleanup.
+//!
+//! Mobile-only by convention — desktop builds never instantiate it
+//! (the trigger button is `cfg(target_os = "android")`-gated). The
+//! component itself compiles on every native target so we don't need
+//! parallel cfg branches in the parent rsx.
+
+use dioxus::prelude::*;
+use serde::Deserialize;
+
+/// IMPORTANT — do **not** wrap the body in `(async () => {...})()`.
+/// `dioxus_desktop::query::QueryEngine::new_query` wraps user scripts
+/// inside `new AsyncFunction("dioxus", SCRIPT)` and treats the
+/// returned Promise as the query lifetime: when that Promise
+/// resolves, `dioxus.close()` is called and any `eval.recv` on the
+/// Rust side returns `Err(channel closed)`. Keep the body flat and
+/// `await` the long-running work directly so the outer Promise only
+/// resolves when we genuinely want to close.
+const SCANNER_JS: &str = r#"
+const send = (kind, value) => {
+    // Pass the object directly. `dioxus.send` already JSON-encodes
+    // the IPC envelope; double-encoding lands on Rust as
+    // `Value::String("{...}")` and fails to deserialize.
+    try { dioxus.send({ kind, value: value || "" }); } catch (e) {}
+};
+
+if (!('BarcodeDetector' in window)) {
+    send('error', 'BarcodeDetector unsupported on this device');
+    return;
+}
+
+let stream = null;
+let stopped = false;
+
+window.__wavesyncQrScannerStop = () => {
+    stopped = true;
+    if (stream) {
+        stream.getTracks().forEach(t => t.stop());
+        stream = null;
+    }
+};
+
+let video;
+try {
+    video = document.getElementById('wavesync-qr-scanner-video');
+    if (!video) {
+        send('error', 'Camera element not found');
+        return;
+    }
+    stream = await navigator.mediaDevices.getUserMedia({
+        video: { facingMode: 'environment' }
+    });
+    if (stopped) {
+        stream.getTracks().forEach(t => t.stop());
+        return;
+    }
+    video.srcObject = stream;
+    await video.play();
+    send('started', '');
+} catch (e) {
+    send('error', String((e && e.message) || e));
+    return;
+}
+
+const detector = new BarcodeDetector({ formats: ['qr_code'] });
+
+while (!stopped) {
+    try {
+        const codes = await detector.detect(video);
+        if (codes && codes.length > 0) {
+            const value = codes[0].rawValue;
+            send('detected', value);
+            if (stream) {
+                stream.getTracks().forEach(t => t.stop());
+                stream = null;
+            }
+            return;
+        }
+    } catch (e) {
+        // Swallow per-frame failures — detector occasionally throws
+        // transiently when the camera resizes / focuses.
+    }
+    await new Promise(r => setTimeout(r, 200));
+}
+"#;
+
+#[derive(Debug, Deserialize)]
+struct ScannerMsg {
+    kind: String,
+    #[serde(default)]
+    value: String,
+}
+
+/// Full-screen QR scanner overlay. On detect, calls `on_detect(raw)`
+/// where `raw` is the QR's text payload (the caller passes that to
+/// `parse_pairing_url`). On user cancel or fatal error, calls
+/// `on_close()` and the parent unmounts the overlay.
+#[component]
+pub fn QrScannerOverlay(on_close: EventHandler<()>, on_detect: EventHandler<String>) -> Element {
+    let mut error = use_signal(|| Option::<String>::None);
+    let mut started = use_signal(|| false);
+
+    use_effect(move || {
+        let mut eval = document::eval(SCANNER_JS);
+        spawn(async move {
+            while let Ok(msg) = eval.recv::<ScannerMsg>().await {
+                match msg.kind.as_str() {
+                    "started" => started.set(true),
+                    "detected" if !msg.value.is_empty() => {
+                        on_detect.call(msg.value);
+                        return;
+                    }
+                    "error" => {
+                        error.set(Some(if msg.value.is_empty() {
+                            "Camera unavailable.".to_string()
+                        } else {
+                            msg.value
+                        }));
+                        return;
+                    }
+                    _ => {}
+                }
+            }
+        });
+    });
+
+    use_drop(|| {
+        document::eval("if (window.__wavesyncQrScannerStop) { window.__wavesyncQrScannerStop(); }");
+    });
+
+    let close = move |_| on_close.call(());
+
+    rsx! {
+        style { {SCANNER_CSS} }
+        div { class: "qr-scanner-overlay",
+            div { class: "qr-scanner-bar",
+                span { class: "qr-scanner-title",
+                    if error().is_some() {
+                        "Scanner error"
+                    } else if started() {
+                        "Point at the pairing QR"
+                    } else {
+                        "Starting camera…"
+                    }
+                }
+                button {
+                    r#type: "button",
+                    class: "qr-scanner-close",
+                    onclick: close,
+                    "Cancel"
+                }
+            }
+            div { class: "qr-scanner-frame",
+                video {
+                    id: "wavesync-qr-scanner-video",
+                    class: "qr-scanner-video",
+                    autoplay: "true",
+                    playsinline: "true",
+                    muted: "true",
+                }
+                div { class: "qr-scanner-guide" }
+            }
+            if let Some(msg) = error() {
+                div { class: "qr-scanner-error",
+                    p { strong { "{msg}" } }
+                    p { "Type the relay multiaddr by hand instead." }
+                    button {
+                        r#type: "button",
+                        class: "qr-scanner-error-close",
+                        onclick: close,
+                        "Close"
+                    }
+                }
+            }
+        }
+    }
+}
+
+const SCANNER_CSS: &str = r#"
+.qr-scanner-overlay {
+    position: fixed;
+    inset: 0;
+    z-index: 60;
+    display: flex;
+    flex-direction: column;
+    background: #000;
+    color: #fff;
+    padding-top: env(safe-area-inset-top, 0);
+    padding-bottom: env(safe-area-inset-bottom, 0);
+}
+.qr-scanner-bar {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    padding: 12px 16px;
+    background: rgba(0, 0, 0, 0.6);
+    backdrop-filter: blur(8px);
+    -webkit-backdrop-filter: blur(8px);
+}
+.qr-scanner-title {
+    font-size: 14px;
+    font-weight: 500;
+}
+.qr-scanner-close {
+    cursor: pointer;
+    border: none;
+    border-radius: 8px;
+    background: rgba(255, 255, 255, 0.15);
+    color: #fff;
+    padding: 6px 12px;
+    font-size: 14px;
+    font-weight: 500;
+}
+.qr-scanner-frame {
+    position: relative;
+    flex: 1;
+    overflow: hidden;
+}
+.qr-scanner-video {
+    position: absolute;
+    inset: 0;
+    height: 100%;
+    width: 100%;
+    object-fit: cover;
+}
+.qr-scanner-guide {
+    pointer-events: none;
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    aspect-ratio: 1 / 1;
+    width: 70%;
+    transform: translate(-50%, -50%);
+    border: 2px solid rgba(255, 255, 255, 0.85);
+    border-radius: 12px;
+    box-shadow: 0 0 0 9999px rgba(0, 0, 0, 0.35);
+}
+.qr-scanner-error {
+    position: absolute;
+    left: 16px;
+    right: 16px;
+    bottom: 24px;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    padding: 16px;
+    border-radius: 12px;
+    background: rgba(0, 0, 0, 0.8);
+    backdrop-filter: blur(8px);
+    -webkit-backdrop-filter: blur(8px);
+    color: #fff;
+    font-size: 14px;
+}
+.qr-scanner-error-close {
+    cursor: pointer;
+    border: none;
+    border-radius: 6px;
+    background: #4a90d9;
+    color: #fff;
+    padding: 8px 16px;
+    font-size: 14px;
+    align-self: flex-start;
+}
+"#;

--- a/examples/qr_pairing/src/task_native.rs
+++ b/examples/qr_pairing/src/task_native.rs
@@ -1,0 +1,30 @@
+//! SeaORM model for the task entity used by the native build.
+//!
+//! Mirrors the field set the web build's plain `Task` struct uses,
+//! so writes from one side land cleanly on the other through the
+//! shared CRDT shadow tables. The web side uses `BrowserEntity`
+//! manually; the native side uses the `#[derive(SyncEntity)]` proc
+//! macro that hooks into SeaORM at link time.
+
+use sea_orm::entity::prelude::*;
+use serde::{Deserialize, Serialize};
+use wavesyncdb::SyncEntity;
+
+#[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel, SyncEntity, Serialize, Deserialize)]
+#[sea_orm(table_name = "tasks")]
+pub struct Model {
+    /// String UUID — same shape as the web side generates so the
+    /// shadow table key (`tasks|<pk>|<cid>`) matches across peers.
+    #[sea_orm(primary_key, auto_increment = false)]
+    pub id: String,
+    pub title: String,
+    pub done: bool,
+    /// Unix milliseconds. Stored as i64 because SQLite has no
+    /// unsigned types; cast to u64 for display sorting.
+    pub created_at: i64,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {}
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/examples/qr_pairing/src/web_app.rs
+++ b/examples/qr_pairing/src/web_app.rs
@@ -1,0 +1,437 @@
+//! Browser side of the QR-pairing example.
+//!
+//! Renders a small pairing form (topic + passphrase — no relay; the
+//! relay multiaddr is hardcoded per platform, same way an app bakes
+//! in a STUN server). Connects the browser via
+//! `WebSyncClient::connect_via_relay`, then once it knows its own
+//! peer-id (read from the engine's status watch channel) generates a
+//! `wavesync://?peer=…&topic=…&pass=…` QR. The phone scans it, joins
+//! the same topic via *its* hardcoded relay, and the two peers
+//! discover each other through the relay's topic mesh.
+
+use std::collections::HashMap;
+
+use dioxus::prelude::*;
+use wavesyncdb::{
+    BrowserEntity, WebSyncClient, WebSyncStatus, dioxus::use_synced_table, serde_json,
+};
+
+use crate::pairing::{PairingParams, build_pairing_url};
+
+const TASK_TABLE: &str = "tasks";
+const STORE_NAME: &str = "qr-pairing-web";
+
+/// PeerId of the default relay (the one the README's
+/// `--identity-keypair` arg pins). Used to build the WebSocket
+/// multiaddr the browser dials.
+const DEFAULT_RELAY_PEER_ID: &str = "12D3KooWP6oyorVZmZvTRPHdxsEyE2V8mR1dTiAZJYoNsMNX19KW";
+
+/// Build the relay multiaddr the *browser* dials. The phone uses its
+/// own hardcoded TCP/4001 multiaddr and never sees this one — the QR
+/// only carries peer-id + topic + pass. `window.location.hostname`
+/// is the dev machine's address as the browser sees it
+/// (`localhost` when serving locally; LAN IP when a phone loads the
+/// page over wifi to inspect the QR).
+fn relay_addr() -> String {
+    let hostname = web_sys::window()
+        .and_then(|w| w.location().hostname().ok())
+        .unwrap_or_else(|| "127.0.0.1".to_string());
+    format!("/ip4/{hostname}/tcp/4002/ws/p2p/{DEFAULT_RELAY_PEER_ID}")
+}
+
+const DEFAULT_TOPIC: &str = "qr-pairing-demo";
+const DEFAULT_PASS: &str = "demo-shared-secret";
+
+#[derive(Clone, Debug, Default)]
+struct Task {
+    id: String,
+    title: String,
+    done: bool,
+    created_at: u64,
+}
+
+impl BrowserEntity for Task {
+    fn from_columns(pk: &str, cols: &HashMap<String, serde_json::Value>) -> Self {
+        Task {
+            id: pk.to_string(),
+            title: cols
+                .get("title")
+                .and_then(|v| v.as_str())
+                .unwrap_or("(untitled)")
+                .to_string(),
+            done: cols.get("done").and_then(|v| v.as_bool()).unwrap_or(false),
+            created_at: cols.get("created_at").and_then(|v| v.as_u64()).unwrap_or(0),
+        }
+    }
+
+    fn to_columns(&self) -> Vec<(String, serde_json::Value)> {
+        vec![
+            (
+                "title".to_string(),
+                serde_json::Value::String(self.title.clone()),
+            ),
+            ("done".to_string(), serde_json::Value::Bool(self.done)),
+            (
+                "created_at".to_string(),
+                serde_json::Value::Number(serde_json::Number::from(self.created_at)),
+            ),
+        ]
+    }
+
+    fn pk(&self) -> String {
+        self.id.clone()
+    }
+}
+
+#[component]
+pub fn App() -> Element {
+    let topic = use_signal(|| DEFAULT_TOPIC.to_string());
+    let pass = use_signal(|| DEFAULT_PASS.to_string());
+    let mut client = use_signal(|| None::<WebSyncClient>);
+    let mut error_msg = use_signal(|| None::<String>);
+
+    // wasmlogger forwards `log::*!` to the browser console. The engine
+    // uses the `log` crate; Dioxus's own logger only captures
+    // `tracing::*!`, so without this the engine's diagnostic
+    // `WebSyncClient: …` lines silently disappear and there's no way
+    // to debug a live tab. `init` is a no-op on its second call so
+    // running this on every App mount is fine.
+    use_hook(|| {
+        wasm_logger::init(wasm_logger::Config::new(log::Level::Info));
+    });
+
+    // Connect on mount. The browser persists its libp2p keypair in
+    // IndexedDB (see `WebSyncClient::connect_via_relay`), so the
+    // peer-id stays stable across reloads — and so a QR generated
+    // on one load remains valid after a refresh.
+    use_hook(move || {
+        let topic_v = topic.peek().clone();
+        let pass_v = pass.peek().clone();
+        let pass_opt = if pass_v.is_empty() {
+            None
+        } else {
+            Some(pass_v)
+        };
+        let addr = relay_addr();
+        spawn(async move {
+            match WebSyncClient::connect_via_relay(&addr, &topic_v, pass_opt.as_deref(), STORE_NAME)
+                .await
+            {
+                Ok(c) => client.set(Some(c)),
+                Err(e) => error_msg.set(Some(format!("connect_via_relay failed: {e}"))),
+            }
+        });
+    });
+
+    rsx! {
+        style { {STYLE} }
+        div { class: "app",
+            h1 { "WaveSyncDB · QR pairing" }
+            p { class: "blurb",
+                "This browser is now a peer. Once it's connected to the relay, the "
+                "QR below carries this tab's libp2p peer-id plus the topic + "
+                "passphrase. Scan it with the phone build of this example — the "
+                "phone joins the same topic via its own hardcoded relay and the "
+                "two sides discover each other through the relay's topic mesh."
+            }
+
+            if let Some(err) = error_msg() {
+                div { class: "panel error-panel",
+                    p { class: "error", "{err}" }
+                }
+            }
+
+            if client().is_some() {
+                PairingPanel { client: client, topic: topic(), pass: pass() }
+                DebugPanel { client: client }
+                TaskList { client: client }
+            } else {
+                div { class: "panel",
+                    h2 { "Pair a phone" }
+                    p { class: "hint", "Connecting to the relay…" }
+                }
+            }
+        }
+    }
+}
+
+/// Renders the QR once we know the local peer-id. Subscribes to the
+/// engine's status watch channel and rebuilds the QR if the peer-id
+/// changes (it shouldn't, post-IndexedDB-keypair, but if a future
+/// refactor invalidates that assumption the QR stays correct).
+#[component]
+fn PairingPanel(client: Signal<Option<WebSyncClient>>, topic: String, pass: String) -> Element {
+    let status = use_sync_status(client);
+    let s = status();
+
+    let qr_svg = use_memo(move || {
+        let s = status();
+        if s.local_peer_id.is_empty() {
+            return None;
+        }
+        let pass_opt = if pass.is_empty() {
+            None
+        } else {
+            Some(pass.clone())
+        };
+        let url = build_pairing_url(&PairingParams {
+            peer_id: s.local_peer_id.clone(),
+            topic: topic.clone(),
+            pass: pass_opt,
+        });
+        match qrcode::QrCode::new(&url) {
+            Ok(code) => Some(
+                code.render::<qrcode::render::svg::Color>()
+                    .min_dimensions(280, 280)
+                    .build(),
+            ),
+            Err(_) => None,
+        }
+    });
+
+    rsx! {
+        div { class: "panel",
+            h2 { "Pair a phone" }
+            p { class: "kv", strong { "This peer-id " }
+                code { class: "wrap", "{s.local_peer_id}" }
+            }
+            if let Some(svg) = qr_svg() {
+                div { class: "qr-wrap",
+                    div { class: "qr", dangerous_inner_html: "{svg}" }
+                    p { class: "hint",
+                        if s.relay_connected {
+                            "Relay online — scan the QR with the phone app."
+                        } else {
+                            "Waiting for relay…"
+                        }
+                    }
+                }
+            } else {
+                p { class: "hint", "Generating QR…" }
+            }
+        }
+    }
+}
+
+#[component]
+fn TaskList(client: Signal<Option<WebSyncClient>>) -> Element {
+    let tasks = use_synced_table::<Task>(client, TASK_TABLE);
+    let mut new_title = use_signal(String::new);
+
+    let do_add = use_callback(move |_: ()| {
+        let title = new_title().trim().to_string();
+        if title.is_empty() {
+            return;
+        }
+        let Some(c) = client() else { return };
+        let task = Task {
+            id: uuid_v4_string(),
+            title,
+            done: false,
+            created_at: now_ms(),
+        };
+        new_title.set(String::new());
+        spawn(async move {
+            let _ = c.submit::<Task>(TASK_TABLE, &task).await;
+        });
+    });
+
+    let toggle = move |t: Task| {
+        let Some(c) = client() else { return };
+        let updated = Task { done: !t.done, ..t };
+        spawn(async move {
+            let _ = c.submit::<Task>(TASK_TABLE, &updated).await;
+        });
+    };
+
+    let mut visible: Vec<Task> = tasks();
+    visible.sort_by_key(|t| std::cmp::Reverse(t.created_at));
+
+    rsx! {
+        div { class: "panel",
+            h2 { "Tasks" }
+            div { class: "add-row",
+                input {
+                    placeholder: "Add a task…",
+                    value: "{new_title}",
+                    oninput: move |e| new_title.set(e.value()),
+                    onkeydown: move |e| {
+                        if e.key() == Key::Enter { do_add(()); }
+                    },
+                }
+                button {
+                    class: "primary",
+                    onclick: move |_| do_add(()),
+                    "Add"
+                }
+            }
+            ul { class: "task-list",
+                if visible.is_empty() {
+                    li { class: "empty", "No tasks yet — add one or wait for the phone." }
+                }
+                for t in visible.into_iter() {
+                    {
+                        let toggle_t = t.clone();
+                        rsx! {
+                            li {
+                                key: "{t.id}",
+                                class: if t.done { "task done" } else { "task" },
+                                input {
+                                    r#type: "checkbox",
+                                    checked: t.done,
+                                    onchange: move |_| toggle(toggle_t.clone()),
+                                }
+                                span { class: "title", "{t.title}" }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Reactive Signal<WebSyncStatus> bound to the engine's watch
+/// channel. On mount, takes a snapshot from `client.subscribe_status()`
+/// and then spawns a future that pumps subsequent updates into the
+/// signal. Cheap — `watch::Receiver::changed()` is push-driven, no
+/// polling.
+fn use_sync_status(client: Signal<Option<WebSyncClient>>) -> Signal<WebSyncStatus> {
+    let mut sig = use_signal(WebSyncStatus::default);
+    use_hook(move || {
+        spawn(async move {
+            // Wait for the client to be ready, then subscribe. Once
+            // subscribed, the loop only exits when the engine drops
+            // (client cleared) — at which point recv()? returns Err.
+            let Some(c) = client.read().clone() else {
+                return;
+            };
+            let mut rx = c.subscribe_status();
+            sig.set(rx.borrow().clone());
+            while rx.changed().await.is_ok() {
+                sig.set(rx.borrow().clone());
+            }
+        });
+    });
+    sig
+}
+
+#[component]
+fn DebugPanel(client: Signal<Option<WebSyncClient>>) -> Element {
+    let status = use_sync_status(client);
+    let s = status();
+    let relay_label = if s.relay_connected {
+        "connected"
+    } else if s.relay_peer_id.is_some() {
+        "connecting"
+    } else {
+        "—"
+    };
+    let relay_class = if s.relay_connected {
+        "value online"
+    } else if s.relay_peer_id.is_some() {
+        "value pending"
+    } else {
+        "value offline"
+    };
+
+    rsx! {
+        div { class: "panel",
+            h2 { "Network" }
+            p { class: "kv", strong { "Local peer-id " }
+                code { class: "wrap", "{s.local_peer_id}" }
+            }
+            if let Some(rid) = s.relay_peer_id.clone() {
+                p { class: "kv", strong { "Relay peer-id " } code { class: "wrap", "{rid}" } }
+            }
+            p { class: "kv", strong { "Relay " }
+                span { class: "{relay_class}", "{relay_label}" }
+            }
+            p { class: "kv", strong { "Peers " }
+                span {
+                    class: if s.connected_peer_ids.is_empty() {
+                        "value offline"
+                    } else {
+                        "value online"
+                    },
+                    "{s.connected_peer_ids.len()} connected"
+                }
+            }
+            if !s.connected_peer_ids.is_empty() {
+                ul { class: "peer-list",
+                    for id in s.connected_peer_ids.iter() {
+                        li { key: "{id}", class: "peer",
+                            code { class: "peer-id-only", "{id}" }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn uuid_v4_string() -> String {
+    let mut bytes = [0u8; 16];
+    getrandom::getrandom(&mut bytes).expect("crypto.getRandomValues failed");
+    bytes[6] = (bytes[6] & 0x0f) | 0x40;
+    bytes[8] = (bytes[8] & 0x3f) | 0x80;
+    format!(
+        "{:02x}{:02x}{:02x}{:02x}-{:02x}{:02x}-{:02x}{:02x}-{:02x}{:02x}-{:02x}{:02x}{:02x}{:02x}{:02x}{:02x}",
+        bytes[0],
+        bytes[1],
+        bytes[2],
+        bytes[3],
+        bytes[4],
+        bytes[5],
+        bytes[6],
+        bytes[7],
+        bytes[8],
+        bytes[9],
+        bytes[10],
+        bytes[11],
+        bytes[12],
+        bytes[13],
+        bytes[14],
+        bytes[15],
+    )
+}
+
+fn now_ms() -> u64 {
+    js_sys::Date::now() as u64
+}
+
+const STYLE: &str = r#"
+body { background: #0a0d12; color: #e6ecf2; font-family: -apple-system, BlinkMacSystemFont, "Inter", "Segoe UI", Roboto, sans-serif; margin: 0; }
+.app { max-width: 760px; margin: 0 auto; padding: 40px 24px; }
+.app h1 { font-size: 1.8rem; margin: 0 0 8px; }
+.blurb { color: #9aa6b6; line-height: 1.55; margin: 0 0 32px; }
+.panel { background: #11151c; border: 1px solid #232a36; border-radius: 12px; padding: 24px; margin-bottom: 24px; }
+.panel h2 { margin: 0 0 16px; font-size: 1.1rem; }
+.panel label { display: block; color: #9aa6b6; font-size: 0.78rem; text-transform: uppercase; letter-spacing: 0.5px; margin-top: 14px; margin-bottom: 4px; }
+.panel input[type="text"], .panel input[type="password"] { width: 100%; padding: 9px 12px; background: #0a0d12; border: 1px solid #303949; border-radius: 6px; color: #e6ecf2; font-family: ui-monospace, "SF Mono", Menlo, monospace; font-size: 0.9rem; box-sizing: border-box; }
+.panel input:focus { outline: none; border-color: #6ce0c9; }
+button.primary { margin-top: 18px; padding: 10px 18px; background: #6ce0c9; color: #06231f; border: none; border-radius: 6px; font-weight: 600; cursor: pointer; }
+button.primary:hover { background: #8ff0d8; }
+.error { margin-top: 14px; padding: 10px; background: rgba(247, 200, 124, 0.08); border: 1px solid #f7c87c; color: #f7c87c; border-radius: 6px; font-size: 0.85rem; }
+.qr-wrap { margin-top: 18px; display: flex; flex-direction: column; align-items: center; gap: 10px; }
+.qr { width: 280px; height: 280px; background: white; padding: 12px; border-radius: 8px; }
+.qr svg { width: 100%; height: 100%; display: block; }
+.hint { font-family: ui-monospace, "SF Mono", Menlo, monospace; font-size: 0.82rem; color: #9aa6b6; margin: 0; }
+.add-row { display: flex; gap: 8px; }
+.add-row input { flex: 1; padding: 9px 12px; background: #0a0d12; border: 1px solid #303949; border-radius: 6px; color: #e6ecf2; font-size: 0.95rem; }
+.add-row button { margin-top: 0; }
+.task-list { list-style: none; margin: 16px 0 0; padding: 0; display: flex; flex-direction: column; gap: 6px; }
+.task { display: flex; align-items: center; gap: 12px; padding: 10px 12px; background: #0a0d12; border: 1px solid #232a36; border-radius: 6px; }
+.task.done .title { text-decoration: line-through; color: #6f7c8e; }
+.task input[type="checkbox"] { accent-color: #6ce0c9; width: 17px; height: 17px; cursor: pointer; }
+.empty { text-align: center; color: #6f7c8e; font-style: italic; padding: 18px; }
+.kv { font-size: 0.85rem; color: #e6ecf2; margin: 4px 0; }
+.kv strong { color: #9aa6b6; font-weight: 500; margin-right: 6px; }
+.kv code, code.wrap { font-size: 0.8rem; word-break: break-all; }
+.value.online { color: #6ce0c9; }
+.value.offline { color: #e74c3c; }
+.value.pending { color: #f39c12; }
+.peer-list { list-style: none; margin: 12px 0 0; padding: 0; display: flex; flex-direction: column; gap: 8px; }
+.peer { padding: 10px 12px; background: #0a0d12; border: 1px solid #232a36; border-radius: 6px; }
+.peer-id-only { font-size: 0.75rem; word-break: break-all; }
+"#;

--- a/examples/qr_pairing/test.maestro.yaml
+++ b/examples/qr_pairing/test.maestro.yaml
@@ -1,0 +1,74 @@
+# Maestro flow that drives the qr-pairing Android app to verify BOTH
+# directions of sync between web and phone via the relay's circuit-relay
+# topic mesh. The web counterpart is `web_driver.js`; together they
+# assert:
+#
+#   1. web → phone — web adds 'from-web', phone sees it
+#      (this flow's `extendedWaitUntil` on 'from-web' succeeds).
+#   2. phone → web — phone adds 'from-phone', web sees it
+#      (verified by web_driver.js's wait at the end).
+#
+# A run is fully green only when both this flow exits 0 AND the
+# parallel web_driver process exits 0. test.sh --full enforces that.
+#
+# Usage:
+#   1. ./test.sh --android        # boots relay + web build + installs APK
+#   2. ./test.sh --full           # everything-in-one orchestrator
+#
+# Notes on the syntax (all hard-won from running this on a real device):
+#   - `extendedWaitUntil` is what supports a custom `timeout` field;
+#     plain `assertVisible` doesn't, and rejects the property.
+#   - `clearState` wipes pairing.json + the SQLite DB so each run starts
+#     from the pairing screen. Without it, a stale pairing from a prior
+#     run skips the form and we miss the assertions below.
+#   - The peer-id input is targeted by its placeholder ("12D3KooW…"),
+#     NOT the "Web peer-id" label — that string also appears in the
+#     panel's help blurb, so the label selector matches the wrong node.
+#   - To dismiss the keyboard we tap the "Topic" label rather than
+#     `hideKeyboard` or `pressKey: Back`. Both keyboard-dismiss commands
+#     send the WebView-backed app to the background on this Android
+#     device (gesture-nav back), which then makes the next tap fail
+#     because the foreground is something else (Telegram, in our case).
+
+appId: com.wavesync.qr_pairing
+---
+- launchApp:
+    clearState: true
+
+- extendedWaitUntil:
+    visible: "Pair this device"
+    timeout: 15000
+
+- tapOn:
+    text: "12D3KooW…"
+- inputText: "12D3KooWtest000000000000000000000000000000000000"
+- tapOn: "Topic"
+- tapOn: "Connect"
+
+- extendedWaitUntil:
+    visible: "Tasks"
+    timeout: 30000
+
+# === Direction 1: web → phone ===
+# Wait for the web side (web_driver.js) to add 'from-web' and have the
+# push fan out to us.
+- extendedWaitUntil:
+    visible: "from-web"
+    timeout: 60000
+
+# === Direction 2: phone → web ===
+# Type 'from-phone' into this app's Tasks input and click Add. The
+# parallel web_driver will assert that this string shows up on its
+# DOM via the inverse Push fan-out.
+#
+# We tap Add directly without dismissing the keyboard first — the
+# input and the Add button live on the same flex row in
+# AddTaskForm, so the button stays visible above the keyboard.
+# The "Topic" label dismiss-trick we use on the pairing screen
+# doesn't exist here (the Tasks screen has no field labelled
+# "Topic"), and `hideKeyboard`/`pressKey: Back` background the
+# WebView app the same way they did during pairing.
+- tapOn:
+    text: "What needs to be done?"
+- inputText: "from-phone"
+- tapOn: "Add"

--- a/examples/qr_pairing/test.sh
+++ b/examples/qr_pairing/test.sh
@@ -1,0 +1,331 @@
+#!/usr/bin/env bash
+# Quick end-to-end test harness for the qr-pairing example.
+#
+# Spins up:
+#   1. wavesync_relay (TCP/QUIC/WS listeners + 3 external addrs + bumped
+#      reservation cap so renewal storms don't trip ResourceLimitExceeded).
+#   2. dx serve --platform web — wasm build of the example, served at :8080.
+#   3. (optional, --android) dx serve --platform android — installs the APK
+#      onto the connected `adb` device.
+#
+# Live-tails `WebSyncClient:` lines from the web log so the diagnostic
+# patterns added in `wavesyncdb/src/web_engine.rs` (connected count,
+# pushing → N peers, send_request, OutboundFailure) show up as soon as
+# they fire.
+#
+# Usage:
+#   ./test.sh             # relay + web (manual driving)
+#   ./test.sh --android   # also install the Android side
+#   ./test.sh --full      # autonomous end-to-end: relay + web + Android +
+#                         #   maestro (drives phone) + puppeteer (drives
+#                         #   web). Pass-fail at the end.
+#   ./test.sh --stop      # stop everything started by a previous run
+#
+# In --full mode:
+#   1. Relay + web build come up the same as the default mode.
+#   2. Android APK is installed on the connected `adb` device.
+#   3. maestro pairs the phone, waits for the Tasks panel.
+#   4. As soon as maestro confirms Tasks is up, the web driver
+#      (web_driver.js) opens the page in headless Chrome and clicks Add
+#      with text 'from-web'.
+#   5. maestro waits up to 60s for 'from-web' to appear on the phone.
+#   6. Pass = real-time web→phone push works. Fail = it doesn't, in
+#      which case the diagnostic logs in $LOGDIR/web.log show whether
+#      web's `connected` set was empty, the send_request fired, etc.
+
+set -euo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../.." && pwd)"
+LOGDIR="$HERE/.test-logs"
+PIDDIR="$HERE/.test-pids"
+mkdir -p "$LOGDIR" "$PIDDIR"
+
+# Identity-keypair pinned so the relay's PeerId is stable across runs —
+# matches DEFAULT_RELAY_PEER_ID in src/web_app.rs and RELAY_PEER_ID in
+# src/native_app.rs.
+RELAY_KEY='CAESQGlCc264ZKF3D4l/5VXTLjnGdDKxg0cyX2UosIkZmNAbxV5oeISRfEDIrc/+hdQuqepe9CCCc3M5G3DJBs6N6lE='
+
+# Web server port. dx serve defaults to 8080 + 127.0.0.1 — both wrong for
+# this test: 8080 is commonly held by another dev server (a leftover
+# `dx serve --platform android` will sit on it for a session), and a
+# 127.0.0.1 bind is unreachable from a phone on the LAN. We pin to a
+# less-trafficked port and bind 0.0.0.0 so the phone can dial the dev
+# machine over wifi. Override via WEB_PORT env var if 8087 collides.
+WEB_PORT="${WEB_PORT:-8087}"
+
+stop_all() {
+    for pidfile in "$PIDDIR"/*.pid; do
+        [[ -f "$pidfile" ]] || continue
+        local name pid
+        name="$(basename "$pidfile" .pid)"
+        pid="$(cat "$pidfile")"
+        if kill -0 "$pid" 2>/dev/null; then
+            # Kill the whole process group — `dx serve` and `cargo run`
+            # spawn children that don't exit when the parent does.
+            kill -TERM -- "-$pid" 2>/dev/null || kill -TERM "$pid" 2>/dev/null || true
+            echo "stopped $name (pid=$pid)"
+        fi
+        rm -f "$pidfile"
+    done
+}
+
+if [[ "${1:-}" == "--stop" ]]; then
+    stop_all
+    exit 0
+fi
+
+# Idempotent: always tear down before starting.
+stop_all
+
+# Detect LAN IP. Prefer 192.168.x.x (the network the user's phone is on
+# for this setup), fall back to first non-loopback global address.
+LAN_IP="$(ip -4 -o addr show scope global 2>/dev/null \
+    | awk '{print $4}' | cut -d/ -f1 \
+    | grep -E '^192\.168\.' | head -1 || true)"
+if [[ -z "$LAN_IP" ]]; then
+    LAN_IP="$(ip -4 -o addr show scope global 2>/dev/null \
+        | awk '{print $4}' | cut -d/ -f1 | head -1 || true)"
+fi
+if [[ -z "$LAN_IP" ]]; then
+    echo "WARNING: no LAN IP detected — using 127.0.0.1 (a real phone won't reach this)"
+    LAN_IP="127.0.0.1"
+fi
+
+# Sync .env so build.rs bakes the correct host into the next native build.
+# This is what `option_env!("WAVESYNC_RELAY_HOST")` reads in
+# src/native_app.rs::RELAY_HOST.
+echo "WAVESYNC_RELAY_HOST=$LAN_IP" > "$HERE/.env"
+echo "LAN IP: $LAN_IP  (written to $HERE/.env)"
+
+# ── Start relay ──────────────────────────────────────────────────────
+echo "Starting relay…"
+(
+    cd "$ROOT"
+    setsid env RUST_LOG=info cargo run --quiet -p wavesync_relay -- \
+        --identity-keypair="$RELAY_KEY" \
+        --listen-addr /ip4/0.0.0.0/tcp/4001 \
+        --ws-listen-addr /ip4/0.0.0.0/tcp/4002/ws \
+        --external-address "/ip4/$LAN_IP/tcp/4001" \
+        --external-address "/ip4/$LAN_IP/udp/4001/quic-v1" \
+        --external-address "/ip4/$LAN_IP/tcp/4002/ws" \
+        --max-reservations-per-peer 256 \
+        </dev/null >"$LOGDIR/relay.log" 2>&1 &
+    echo $! > "$PIDDIR/relay.pid"
+)
+
+# Block until the relay prints its first listen line.
+until grep -q "Also listening on WebSocket" "$LOGDIR/relay.log" 2>/dev/null; do
+    if ! kill -0 "$(cat "$PIDDIR/relay.pid")" 2>/dev/null; then
+        echo "Relay died early; tail of log:"
+        tail -30 "$LOGDIR/relay.log"
+        exit 1
+    fi
+    sleep 0.5
+done
+echo "  relay up (logs: $LOGDIR/relay.log)"
+
+# ── Start web (dx serve --platform web) ──────────────────────────────
+# Sanity-check the port before launching dx — dx silently falls back to
+# a random ephemeral port when its requested port is busy, which would
+# leave us claiming "served at $WEB_PORT" while it's actually elsewhere.
+if ss -tlnH "sport = :$WEB_PORT" 2>/dev/null | grep -q .; then
+    echo "ERROR: port $WEB_PORT already in use. Set WEB_PORT=<n> and retry, or stop:"
+    ss -tlnpH "sport = :$WEB_PORT" 2>/dev/null
+    stop_all
+    exit 1
+fi
+
+echo "Starting web build on 0.0.0.0:$WEB_PORT (this takes 30–60s on a clean target)…"
+(
+    cd "$HERE"
+    setsid env RUST_LOG=info,wavesyncdb=info dx serve --platform web \
+        --addr 0.0.0.0 --port "$WEB_PORT" \
+        </dev/null >"$LOGDIR/web.log" 2>&1 &
+    echo $! > "$PIDDIR/web.pid"
+)
+
+until grep -qE "Build completed successfully|launching app" "$LOGDIR/web.log" 2>/dev/null; do
+    if ! kill -0 "$(cat "$PIDDIR/web.pid")" 2>/dev/null; then
+        echo "dx serve --platform web died; tail of log:"
+        tail -30 "$LOGDIR/web.log"
+        exit 1
+    fi
+    sleep 1
+done
+echo "  web served at http://$LAN_IP:$WEB_PORT (logs: $LOGDIR/web.log)"
+
+# ── Optional Android ─────────────────────────────────────────────────
+if [[ "${1:-}" == "--android" || "${1:-}" == "--full" ]]; then
+    if ! adb get-state >/dev/null 2>&1; then
+        echo "No adb device connected — skipping Android"
+    elif [[ "${SKIP_ANDROID_BUILD:-}" == "1" ]] \
+        && adb shell pm list packages 2>/dev/null | grep -q "package:com.wavesync.qr_pairing"; then
+        echo "SKIP_ANDROID_BUILD=1 and app is already installed — using existing APK"
+    else
+        echo "Building + installing Android (this takes 1–3 min on a clean target)…"
+        (
+            cd "$HERE"
+            setsid env RUST_LOG=info dx serve --platform android \
+                </dev/null >"$LOGDIR/android.log" 2>&1 &
+            echo $! > "$PIDDIR/android.pid"
+        )
+        until grep -qE "Build completed successfully|app launched|launching app" \
+            "$LOGDIR/android.log" 2>/dev/null; do
+            if ! kill -0 "$(cat "$PIDDIR/android.pid")" 2>/dev/null; then
+                echo "dx serve --platform android died; tail of log:"
+                tail -30 "$LOGDIR/android.log"
+                exit 1
+            fi
+            sleep 2
+        done
+        echo "  Android installed (logs: $LOGDIR/android.log; logcat: adb logcat -s WaveSyncDB)"
+    fi
+fi
+
+# ── --full: orchestrate end-to-end pass/fail ─────────────────────────
+if [[ "${1:-}" == "--full" ]]; then
+    MAESTRO_BIN="${MAESTRO_BIN:-$HOME/.maestro/bin/maestro}"
+    if [[ ! -x "$MAESTRO_BIN" ]]; then
+        echo "ERROR: maestro not found at $MAESTRO_BIN. Install via 'curl -Ls \"https://get.maestro.mobile.dev\" | bash' or set MAESTRO_BIN=<path>."
+        stop_all
+        exit 1
+    fi
+    if [[ ! -d "$HERE/node_modules/puppeteer-core" ]]; then
+        echo "ERROR: puppeteer-core not installed. Run 'npm install --save-dev puppeteer-core' in $HERE."
+        stop_all
+        exit 1
+    fi
+
+    cat <<EOF
+
+=== Bidirectional driving ===
+  Phone (maestro):
+    1. pair, 2. wait 'from-web' (web→phone proves), 3. type 'from-phone' + Add
+  Web (web_driver.js):
+    1. open page, 2. wait >=1 connected peer, 3. type 'from-web' + Add,
+    4. wait 'from-phone' to land in DOM (phone→web proves)
+
+EOF
+
+    # Capture phone-side logs in parallel so we can correlate with the
+    # web-side diagnostics. clear-then-tail avoids any stale chunks
+    # from a previous run muddying the pass/fail post-mortem.
+    adb logcat -c 2>/dev/null || true
+    setsid adb logcat -v time WaveSyncDB:V '*:S' \
+        </dev/null >"$LOGDIR/phone.log" 2>&1 &
+    LOGCAT_PID=$!
+    echo $LOGCAT_PID > "$PIDDIR/logcat.pid"
+
+    # Drive the phone in background. The `from-web` wait at the end is
+    # what the web side will satisfy once we trigger it below.
+    setsid "$MAESTRO_BIN" test --no-ansi "$HERE/test.maestro.yaml" \
+        </dev/null >"$LOGDIR/maestro.log" 2>&1 &
+    MAESTRO_PID=$!
+    echo $MAESTRO_PID > "$PIDDIR/maestro.pid"
+
+    # Wait for the phone to reach the Tasks view (i.e. paired and on the
+    # topic mesh). After this point the web's Push fan-out has someone
+    # to deliver to. Poll the maestro log; bail if maestro dies first.
+    echo "  waiting for phone to pair…"
+    until grep -q '"Tasks" is visible... COMPLETED' "$LOGDIR/maestro.log" 2>/dev/null; do
+        if ! kill -0 "$MAESTRO_PID" 2>/dev/null; then
+            echo "  maestro died before phone paired — last lines:"
+            tail -40 "$LOGDIR/maestro.log"
+            stop_all
+            exit 1
+        fi
+        sleep 1
+    done
+    echo "  phone paired and on the topic mesh"
+
+    # Drive the web side. web_driver.js types 'from-web', then waits
+    # for 'from-phone' to appear on the page so it asserts both
+    # directions before exiting.
+    echo "  adding 'from-web' on the web side, waiting for phone→web 'from-phone'"
+    setsid env WEB_URL="http://$LAN_IP:$WEB_PORT" \
+        TASK_TEXT=from-web EXPECT_TASK_TEXT=from-phone HEADLESS=1 \
+        node "$HERE/web_driver.js" \
+        </dev/null >"$LOGDIR/web_driver.log" 2>&1 &
+    DRIVER_PID=$!
+    echo $DRIVER_PID > "$PIDDIR/driver.pid"
+
+    # Block on both sides. Maestro proves web→phone (it asserts
+    # 'from-web' visible, then types 'from-phone'). web_driver proves
+    # phone→web (it waits for 'from-phone' in its DOM after typing
+    # 'from-web' itself). Both must exit 0 for a green run.
+    MAESTRO_RC=0
+    DRIVER_RC=0
+    wait "$MAESTRO_PID" || MAESTRO_RC=$?
+    wait "$DRIVER_PID"  || DRIVER_RC=$?
+
+    EXIT=0
+    echo ""
+    if [[ $MAESTRO_RC -eq 0 ]]; then
+        echo "  ✓ web→phone — phone saw 'from-web' (maestro)"
+    else
+        echo "  ✗ web→phone — phone never saw 'from-web' (maestro rc=$MAESTRO_RC)"
+        EXIT=1
+    fi
+    if [[ $DRIVER_RC -eq 0 ]]; then
+        echo "  ✓ phone→web — web saw 'from-phone' (web_driver)"
+    else
+        echo "  ✗ phone→web — web never saw 'from-phone' (web_driver rc=$DRIVER_RC)"
+        EXIT=1
+    fi
+
+    if [[ $EXIT -eq 0 ]]; then
+        echo ""
+        echo "=== ✓ PASS — both directions sync in real time ==="
+    else
+        echo ""
+        echo "=== ✗ FAIL ==="
+        if [[ $MAESTRO_RC -ne 0 ]]; then
+            echo ""
+            echo "Maestro tail:"
+            tail -25 "$LOGDIR/maestro.log"
+        fi
+        if [[ $DRIVER_RC -ne 0 ]]; then
+            echo ""
+            echo "web_driver tail:"
+            tail -25 "$LOGDIR/web_driver.log" | grep -v "Multiplexed\|with_other_transport\|::start::"
+        fi
+        echo ""
+        echo "Web wasm diagnostics (look for 'pushing changeset to N peers' and 'connected count'):"
+        grep -E "WebSyncClient:" "$LOGDIR/web_driver.log" \
+            | grep -vE "Multiplexed|with_other_transport|::start::" \
+            | sed -E 's/.*WebSyncClient: //;s/;\s+color:.*//' | tail -20
+    fi
+
+    # Tear down logcat tail — leave the rest of the env up unless the
+    # user explicitly stops it. They may want to inspect logs.
+    kill -TERM -- "-$LOGCAT_PID" 2>/dev/null || kill -TERM "$LOGCAT_PID" 2>/dev/null || true
+    rm -f "$PIDDIR/driver.pid" "$PIDDIR/maestro.pid" "$PIDDIR/logcat.pid"
+    echo ""
+    echo "Logs preserved in $LOGDIR/. Stop everything with '$0 --stop'."
+    exit $EXIT
+fi
+
+cat <<EOF
+
+=== Ready ===
+  Web URL:    http://$LAN_IP:$WEB_PORT
+  Phone:      $([[ "${1:-}" == "--android" ]] && echo "installed via dx (re-install with adb if needed)" || echo "(skipped — pass --android to build/install)")
+
+  Logs:       $LOGDIR/{relay,web,android}.log
+  Stop all:   $0 --stop
+
+  Drive the phone: maestro test $HERE/test.maestro.yaml
+  Drive the web:   open the URL, type 'from-web' in the Tasks panel, click Add
+  Or full auto:    $0 --full
+
+Live-tailing 'WebSyncClient:' from the web log (Ctrl+C stops the tail; the
+processes keep running until you call '$0 --stop'):
+
+EOF
+
+# Foreground tail so the user sees the diagnostic lines as they fire.
+# Filter to the high-signal patterns: connected/disconnected, push fan-out,
+# send_request, outbound failures, panics.
+exec tail -F "$LOGDIR/web.log" 2>/dev/null \
+    | grep --line-buffered -E "WebSyncClient:|panicked|ERROR|connected to relay|connected to peer|disconnected from"

--- a/examples/qr_pairing/web_driver.js
+++ b/examples/qr_pairing/web_driver.js
@@ -1,0 +1,145 @@
+// Headless-Chrome driver for the qr-pairing web build.
+//
+// Opens the page, waits for the WebSyncClient to come up (signalled by
+// the QR appearing — `qr_svg` is non-empty only after the local peer-id
+// is known and a relay connection round-trip has completed), then types
+// "from-web" into the Tasks input and clicks Add. Pipes the page's
+// console (which is where wasm `log::*!` lands via `wasm-logger`) to
+// stderr, prefixed with [wasm], so the diagnostic `WebSyncClient:`
+// lines show up in the same stream as the dx serve output.
+//
+// After Add, the driver also waits for `EXPECT_TASK_TEXT` to appear in
+// the page DOM — this lets the orchestrator assert the *other*
+// direction (phone→web) too. The phone-side maestro flow types
+// "from-phone" and clicks Add a moment after seeing "from-web"; if
+// that string never shows up here within EXPECT_TIMEOUT_MS, phone→web
+// push is broken and the driver exits non-zero.
+//
+// Stays running until that assertion completes (or until killed if
+// EXPECT_TASK_TEXT is empty). Without keeping the swarm alive the
+// connection drops as soon as we close the page.
+//
+// Used by test.sh --full to chain web Add → phone Add → both
+// assertions in one command. Standalone:
+//   WEB_URL=http://192.168.1.150:8087 TASK_TEXT=from-web node web_driver.js
+//
+// Env vars:
+//   WEB_URL            — page to open (default http://localhost:8087)
+//   TASK_TEXT          — string typed into the Tasks input (default 'from-web')
+//   EXPECT_TASK_TEXT   — string we wait for in the DOM after Add (default 'from-phone'; set empty to disable)
+//   HEADLESS           — '0' to launch a visible window (debugging)
+//   READY_TIMEOUT_MS   — abort if the QR doesn't appear in this window (default 60000)
+//   EXPECT_TIMEOUT_MS  — give up waiting for EXPECT_TASK_TEXT after this (default 60000)
+
+const puppeteer = require('puppeteer-core');
+
+const WEB_URL = process.env.WEB_URL || 'http://localhost:8087';
+const TASK_TEXT = process.env.TASK_TEXT || 'from-web';
+const EXPECT_TASK_TEXT = process.env.EXPECT_TASK_TEXT ?? 'from-phone';
+const HEADLESS = process.env.HEADLESS !== '0';
+const READY_TIMEOUT_MS = Number(process.env.READY_TIMEOUT_MS || 60000);
+const EXPECT_TIMEOUT_MS = Number(process.env.EXPECT_TIMEOUT_MS || 60000);
+
+function log(...args) {
+    process.stderr.write('[web_driver] ' + args.join(' ') + '\n');
+}
+
+async function main() {
+    const browser = await puppeteer.launch({
+        executablePath: '/usr/bin/google-chrome-stable',
+        headless: HEADLESS ? 'new' : false,
+        args: ['--no-sandbox', '--disable-dev-shm-usage'],
+    });
+    process.on('SIGINT', () => browser.close().then(() => process.exit(130)));
+    process.on('SIGTERM', () => browser.close().then(() => process.exit(143)));
+
+    const page = await browser.newPage();
+    page.on('console', msg => process.stderr.write('[wasm] ' + msg.text() + '\n'));
+    page.on('pageerror', err => process.stderr.write('[wasm-err] ' + err.message + '\n'));
+
+    log('opening', WEB_URL);
+    await page.goto(WEB_URL, { waitUntil: 'domcontentloaded' });
+
+    // QR rendering only proves the engine has a local peer-id — it
+    // shows up the moment `WebSyncClient::start` returns. To prove the
+    // peer-discovery round-trip actually landed someone in the
+    // engine's `connected` set we wait on the DebugPanel's "Peers N
+    // connected" text. With N >= 1 the next Add will fan out to that
+    // peer; without it, the push goes to nobody (silently — engine
+    // logs `pushing changeset to 0 peer(s)`) and the bug looks the
+    // same as a real delivery failure. Distinguishing the two is the
+    // whole point of this driver.
+    log('waiting for QR…');
+    await page.waitForSelector('.qr svg', { timeout: READY_TIMEOUT_MS });
+    log('QR visible (engine has local peer-id) — now waiting for >=1 connected peer');
+
+    try {
+        await page.waitForFunction(
+            // The Peers row in DebugPanel is rendered as
+            //   <p class="kv"><strong>Peers </strong><span class="value online|offline">N connected</span></p>
+            // — pick the span by its sibling text and assert N>0.
+            () => {
+                const peersSpan = Array.from(document.querySelectorAll('p.kv'))
+                    .find(p => p.querySelector('strong')?.textContent.trim() === 'Peers')
+                    ?.querySelector('span');
+                if (!peersSpan) return false;
+                const n = parseInt(peersSpan.textContent, 10);
+                return Number.isFinite(n) && n >= 1;
+            },
+            { timeout: READY_TIMEOUT_MS, polling: 500 }
+        );
+        log('engine has >=1 peer connected — ready to push');
+    } catch (e) {
+        // Don't bail — adding anyway lets us prove the failure mode is
+        // "fan-out to 0 peers" via the log diagnostics, rather than a
+        // pre-condition timeout that hides what's actually broken.
+        log('WARNING: timed out waiting for connected peer — adding task anyway so the failure shows up in logs as "pushing to 0 peers"');
+    }
+
+    // Identify the Tasks input via its placeholder so we don't
+    // accidentally hit the (separate) topic/passphrase fields. There's
+    // exactly one element with placeholder "Add a task…".
+    const inputHandle = await page.waitForSelector('input[placeholder="Add a task…"]');
+    await inputHandle.click({ clickCount: 3 });   // select existing text if any
+    await inputHandle.type(TASK_TEXT, { delay: 25 });
+
+    // The Add button is a sibling — click via XPath text match.
+    const [addBtn] = await page.$$('button.primary');
+    if (!addBtn) throw new Error('Add button not found');
+    log(`clicking Add for task '${TASK_TEXT}'`);
+    await addBtn.click();
+
+    if (!EXPECT_TASK_TEXT) {
+        log('EXPECT_TASK_TEXT is empty — keeping browser open (Ctrl+C to exit)');
+        await new Promise(() => {});
+        return;
+    }
+
+    log(`waiting for '${EXPECT_TASK_TEXT}' to land in the DOM (phone→web direction)`);
+    try {
+        await page.waitForFunction(
+            text => {
+                // Match against the rendered task list. Using innerText
+                // catches both the Tasks panel and any debug copy of
+                // the same string, but that's fine — what we're proving
+                // is that the changeset reached the engine and made it
+                // into the reactive view.
+                return document.body.innerText.includes(text);
+            },
+            { timeout: EXPECT_TIMEOUT_MS, polling: 500 },
+            EXPECT_TASK_TEXT
+        );
+        log(`OK — '${EXPECT_TASK_TEXT}' appeared on the web side (phone→web push works)`);
+    } catch (e) {
+        log(`FAIL — '${EXPECT_TASK_TEXT}' did not appear within ${EXPECT_TIMEOUT_MS}ms`);
+        await browser.close();
+        process.exit(2);
+    }
+
+    await browser.close();
+}
+
+main().catch(err => {
+    log('FATAL:', err.stack || err.message || String(err));
+    process.exit(1);
+});

--- a/tests-e2e/src/bin/test_peer.rs
+++ b/tests-e2e/src/bin/test_peer.rs
@@ -66,8 +66,8 @@ async fn main() -> Result<()> {
     let db_url = std::env::var("DB_URL").context("DB_URL is required")?;
     let topic = std::env::var("TOPIC").context("TOPIC is required")?;
 
-    let mut builder = WaveSyncDbBuilder::new(&db_url, &topic)
-        .with_sync_interval(Duration::from_secs(2));
+    let mut builder =
+        WaveSyncDbBuilder::new(&db_url, &topic).with_sync_interval(Duration::from_secs(2));
 
     if let Ok(p) = std::env::var("PASSPHRASE")
         && !p.is_empty()
@@ -176,11 +176,9 @@ impl IntoResponse for AppError {
     fn into_response(self) -> axum::response::Response {
         match self {
             AppError::NotFound => (StatusCode::NOT_FOUND, "not found").into_response(),
-            AppError::Db(e) => (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                format!("db error: {e}"),
-            )
-                .into_response(),
+            AppError::Db(e) => {
+                (StatusCode::INTERNAL_SERVER_ERROR, format!("db error: {e}")).into_response()
+            }
         }
     }
 }

--- a/tests-e2e/src/lib.rs
+++ b/tests-e2e/src/lib.rs
@@ -103,8 +103,11 @@ impl WaveSyncE2eHarness {
         //    without a runtime discovery step.
         let relay_keypair = Keypair::generate_ed25519();
         let relay_peer_id = relay_keypair.public().to_peer_id();
-        let relay_identity_b64 =
-            B64.encode(relay_keypair.to_protobuf_encoding().context("encode keypair")?);
+        let relay_identity_b64 = B64.encode(
+            relay_keypair
+                .to_protobuf_encoding()
+                .context("encode keypair")?,
+        );
 
         // 2. Per-harness Docker network.
         let net_name = format!("wavesync-e2e-{suffix}");
@@ -316,12 +319,7 @@ impl RunningPeer {
 
     /// Block until a task with the given pk is visible at this peer, or
     /// time out. Used by scenarios to assert convergence.
-    pub async fn wait_for_task(
-        &self,
-        id: &str,
-        title: &str,
-        timeout: Duration,
-    ) -> Result<()> {
+    pub async fn wait_for_task(&self, id: &str, title: &str, timeout: Duration) -> Result<()> {
         let start = Instant::now();
         let mut interval = Duration::from_millis(50);
         loop {
@@ -356,4 +354,3 @@ pub struct Task {
 struct PeersResponse {
     connected: usize,
 }
-

--- a/tests-e2e/tests/partition_recovery.rs
+++ b/tests-e2e/tests/partition_recovery.rs
@@ -51,7 +51,10 @@ async fn peer_restart_then_rejoin_converges() -> Result<()> {
     for i in 0..5 {
         let id = format!("offline-{i}");
         let title = format!("written while bob was offline {i}");
-        harness.peer("alice").insert_task(&id, &title, false).await?;
+        harness
+            .peer("alice")
+            .insert_task(&id, &title, false)
+            .await?;
     }
 
     // Phase 3: start Bob back up. Bob's `/data/peer.db` survives the

--- a/wavesync_relay/Cargo.toml
+++ b/wavesync_relay/Cargo.toml
@@ -14,7 +14,7 @@ path = "src/main.rs"
 # the build context to this subdirectory. Keep these versions in sync
 # with the workspace root's `[workspace.dependencies]` on bumps.
 [dependencies]
-libp2p = { version = "0.56.0", features = ["relay", "rendezvous", "identify", "ping", "autonat", "request-response", "tokio", "noise", "yamux", "tcp", "quic"] }
+libp2p = { version = "0.56.0", features = ["relay", "rendezvous", "identify", "ping", "autonat", "request-response", "tokio", "noise", "yamux", "tcp", "quic", "websocket", "dns"] }
 libp2p-swarm-derive = "0.35.1"
 tokio = { version = "1.47", features = ["full"] }
 log = "0.4"

--- a/wavesync_relay/src/main.rs
+++ b/wavesync_relay/src/main.rs
@@ -31,6 +31,16 @@ struct Cli {
     #[arg(long, env = "LISTEN_ADDR", default_value = "/ip4/0.0.0.0/tcp/4001")]
     listen_addr: String,
 
+    /// Optional WebSocket listen address for browser peers, e.g.
+    /// `/ip4/0.0.0.0/tcp/4002/ws`. When set, the relay accepts inbound
+    /// libp2p connections over plain WebSocket — wasm32/Dioxus-web peers
+    /// dial this address with `WebSyncClient::connect`. TLS is expected
+    /// to be terminated by a reverse proxy in production (the browser
+    /// then dials `/dns4/<host>/tcp/443/wss/p2p/<peer-id>`); set this
+    /// to empty to disable.
+    #[arg(long, env = "WS_LISTEN_ADDR", default_value = "")]
+    ws_listen_addr: String,
+
     /// Path to a file containing the persistent identity keypair.
     /// If the file does not exist, a new keypair is generated and saved.
     #[arg(long, env = "IDENTITY_FILE")]
@@ -237,11 +247,7 @@ mod resolve_secret_source_tests {
         let path = temp_file_path("explicit");
         std::fs::write(&path, b"{\"x\": 1}").unwrap();
         let explicit = "{\"inline\": true}".to_string();
-        let got = resolve_secret_source(
-            "test",
-            Some(&explicit),
-            path.to_str().unwrap(),
-        );
+        let got = resolve_secret_source("test", Some(&explicit), path.to_str().unwrap());
         assert_eq!(got, Some(explicit));
         let _ = std::fs::remove_file(&path);
     }
@@ -389,27 +395,31 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // populated file, fall through to IDENTITY_FILE (generate-and-persist)
     // rather than crashing — makes the docker-compose setup forgiving when a
     // user deploys without populating every secret mount.
+    //
+    // Disambiguation: base64's alphabet includes `/`, so a "looks like a
+    // path because it contains a slash" heuristic misclassifies legitimate
+    // base64 strings as paths and drops the keypair. Try parsing the value
+    // *as inline base64-encoded protobuf first*; if that produces a valid
+    // keypair, use it. Only fall back to treating it as a file path when
+    // direct parsing fails — at which point it really must be a path
+    // (or garbage, in which case the file won't exist either).
     let keypair_from_keypair_value = cli.identity_keypair.as_ref().and_then(|value| {
-        let looks_like_path = value.contains('/') || value.contains('\\');
-        let b64 = if looks_like_path {
-            read_optional_secret("IDENTITY_KEYPAIR", value)?
-                .trim()
-                .to_string()
-        } else {
-            value.trim().to_string()
+        let trimmed = value.trim();
+        let try_decode = |b64: &str| -> Option<identity::Keypair> {
+            let bytes = base64::engine::general_purpose::STANDARD.decode(b64).ok()?;
+            identity::Keypair::from_protobuf_encoding(&bytes).ok()
         };
-        match base64::engine::general_purpose::STANDARD.decode(&b64) {
-            Ok(bytes) => match identity::Keypair::from_protobuf_encoding(&bytes) {
-                Ok(kp) => Some(kp),
-                Err(e) => {
-                    log::warn!(
-                        "IDENTITY_KEYPAIR not a valid protobuf-encoded keypair ({e}); falling back"
-                    );
-                    None
-                }
-            },
-            Err(e) => {
-                log::warn!("IDENTITY_KEYPAIR not valid base64 ({e}); falling back");
+        if let Some(kp) = try_decode(trimmed) {
+            return Some(kp);
+        }
+        // Not a valid inline base64 keypair — try as a file path next.
+        let from_file = read_optional_secret("IDENTITY_KEYPAIR", value)?;
+        match try_decode(from_file.trim()) {
+            Some(kp) => Some(kp),
+            None => {
+                log::warn!(
+                    "IDENTITY_KEYPAIR file at {value:?} did not contain a valid base64-encoded protobuf keypair; falling back"
+                );
                 None
             }
         }
@@ -519,6 +529,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             yamux::Config::default,
         )?
         .with_quic()
+        // Stack a WebSocket transport on top so browser peers (libp2p
+        // websocket-websys) can dial the relay. The transport itself is
+        // unconditional — `listen_on(.../ws)` is what actually opens the
+        // server socket, and that's gated on `--ws-listen-addr`.
+        // `with_websocket` lives in `WebsocketPhase`, reachable from
+        // `OtherTransportPhase` via `with_dns()`.
+        .with_dns()?
+        .with_websocket(noise::Config::new, yamux::Config::default)
+        .await?
         .with_behaviour(|key| {
             let identify = identify::Behaviour::new(identify::Config::new(
                 "/wavesync-relay/1.0.0".into(),
@@ -575,6 +594,19 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         let quic_addr: Multiaddr = format!("/ip4/0.0.0.0/udp/{port}/quic-v1").parse()?;
         swarm.listen_on(quic_addr.clone())?;
         log::info!("Also listening on {quic_addr}");
+    }
+
+    // Optional WebSocket listener for browser peers. Plain `/ws` is
+    // intended to sit behind a TLS-terminating reverse proxy (nginx,
+    // Caddy) — browsers will dial the public `/wss` address and the
+    // proxy unwraps it to plain WS for the relay. If the deployment
+    // exposes the relay directly to the public Internet, terminate TLS
+    // here instead (libp2p has no built-in `/wss` listener; use a
+    // reverse proxy or the `with_websocket-tls` upgrade variant).
+    if !cli.ws_listen_addr.is_empty() {
+        let ws_addr: Multiaddr = cli.ws_listen_addr.parse()?;
+        swarm.listen_on(ws_addr.clone())?;
+        log::info!("Also listening on WebSocket {ws_addr} (browser peers)");
     }
 
     // Track connected peer addresses for FCM push payloads.
@@ -1117,7 +1149,10 @@ mod cap_peer_addresses_tests {
         // Oldest 3 dropped → first remaining is index 3
         assert_eq!(addrs[0], ma("/ip4/10.0.0.3/tcp/3"));
         // Newest is still last
-        assert_eq!(addrs.last().unwrap(), &ma(&format!("/ip4/10.0.0.{}/tcp/{}", total - 1, total - 1)));
+        assert_eq!(
+            addrs.last().unwrap(),
+            &ma(&format!("/ip4/10.0.0.{}/tcp/{}", total - 1, total - 1))
+        );
     }
 }
 
@@ -1133,10 +1168,7 @@ mod classify_addr_tests {
     fn private_v4_ranges_are_private() {
         // Wi-Fi LAN and corporate LAN remain Private — useful when receiver
         // happens to be on the same network.
-        for s in [
-            "/ip4/192.168.1.150/tcp/4001",
-            "/ip4/10.0.0.5/tcp/4001",
-        ] {
+        for s in ["/ip4/192.168.1.150/tcp/4001", "/ip4/10.0.0.5/tcp/4001"] {
             assert_eq!(classify_addr(&ma(s)), AddrClass::Private, "{s}");
         }
     }
@@ -1238,10 +1270,10 @@ mod build_peer_addrs_for_fcm_tests {
         let peer = pid("12D3KooWQTV2REAJX77iesp2Qjax5tiK7Zt65FA7tUL6Ch47BJc6");
         let relay = pid("12D3KooWFnxFFxCm5ywp5j2WhBV4HbtCLDDh1jAr1QYa3xMtkAy3");
         let known: Vec<Multiaddr> = vec![
-            ma("/ip4/127.0.0.1/tcp/39981"),       // dropped (loopback)
-            ma("/ip4/172.18.0.1/tcp/39981"),      // dropped (Docker bridge)
-            ma("/ip4/192.168.1.150/tcp/39981"),   // private (Wi-Fi LAN)
-            ma("/ip4/79.116.240.142/tcp/42674"),  // public
+            ma("/ip4/127.0.0.1/tcp/39981"),      // dropped (loopback)
+            ma("/ip4/172.18.0.1/tcp/39981"),     // dropped (Docker bridge)
+            ma("/ip4/192.168.1.150/tcp/39981"),  // private (Wi-Fi LAN)
+            ma("/ip4/79.116.240.142/tcp/42674"), // public
         ];
         let external_addrs: Vec<Multiaddr> = vec![
             ma("/ip4/77.37.125.212/tcp/4001"),

--- a/wavesync_relay/src/push_notifier.rs
+++ b/wavesync_relay/src/push_notifier.rs
@@ -181,11 +181,7 @@ async fn fire_notifications(
                 // upstream API. Token is truncated to first 20 chars to avoid
                 // dumping full credentials into log aggregators.
                 let short = token_entry.token.chars().take(20).collect::<String>();
-                log::info!(
-                    "Push sent ({}) to token={}...",
-                    token_entry.platform,
-                    short
-                );
+                log::info!("Push sent ({}) to token={}...", token_entry.platform, short);
             }
             PushResult::TokenInvalid => {
                 log::info!(

--- a/wavesyncdb/Cargo.toml
+++ b/wavesyncdb/Cargo.toml
@@ -7,23 +7,61 @@ description = "WaveSyncDB is a lightweight, distributed database synchronization
 repository = "https://github.com/pvg13/WaveSyncDB"
 readme = "README.md"
 
+# Dependencies that work on every target (including wasm32-unknown-unknown).
+# Anything that pulls in OS sockets, native sqlite, or full tokio belongs in
+# the `[target.'cfg(not(target_arch = "wasm32"))']` block below.
 [dependencies]
-sea-orm = { workspace = true }
 serde = { workspace = true }
-tokio = { workspace = true }
-libp2p = { workspace = true }
-libp2p-swarm-derive = "0.35.1"
-async-trait = "0.1"
 futures = "0.3"
 log = { workspace = true }
 thiserror = { workspace = true }
 serde_json = "1.0"
-uuid = { workspace = true }
 inventory = { workspace = true }
 blake3 = "1"
+async-trait = "0.1"
 wavesyncdb_derive = { path = "../wavesyncdb_derive", optional = true }
 dioxus = { version = "0.7.6", optional = true }
 manganis = { version = "0.7.6", optional = true }
+
+# Native targets: full sync engine, libp2p transports, sea-orm with sqlx-sqlite,
+# tokio with the OS-I/O surface. None of these compile on wasm32-unknown-unknown.
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+sea-orm = { workspace = true }
+tokio = { workspace = true }
+libp2p = { workspace = true }
+libp2p-swarm-derive = "0.35.1"
+uuid = { workspace = true }
+
+# Wasm32 (browser): no sqlx, no tokio I/O. Provide a minimal wasm-friendly
+# tokio for `sync` primitives only, uuid with `js` for browser entropy, and
+# a libp2p subset that uses WebSocket-websys as the only transport — the
+# only browser-native libp2p transport with mature support and no
+# certificate-pinning friction. WebTransport/WebRTC could be added later.
+#
+# sea-orm is intentionally absent (libsqlite3-sys is a C dep). Browser
+# storage (IndexedDB-backed shadow tables) is a future opt-in.
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+tokio = { version = "1.47", default-features = false, features = ["sync", "macros"] }
+uuid = { version = "1", features = ["v4", "js"] }
+libp2p = { version = "0.56.0", default-features = false, features = ["websocket-websys", "request-response", "noise", "yamux", "ping", "identify", "serde", "wasm-bindgen", "macros", "relay"] }
+wasm-bindgen-futures = "0.4"
+gloo-timers = { version = "0.3", features = ["futures"] }
+getrandom = { version = "0.2", features = ["js"] }
+# getrandom 0.3 is pulled in transitively via libp2p → yamux → rand 0.9;
+# enabling its `wasm_js` feature here ensures the browser-entropy backend
+# is selected. The companion `getrandom_backend="wasm_js"` rustflag lives
+# in `.cargo/config.toml`.
+getrandom_03 = { package = "getrandom", version = "0.3", features = ["wasm_js"] }
+# Browser-side persistent storage for identity + shadow tables + db_version.
+# `idb` is a thin async wrapper over the IndexedDB Web API; without it,
+# raw web-sys IDB is event-callback-driven and would require ~200 lines of
+# oneshot-channel plumbing to interact with as `async`. Persistence is
+# what lets a reloaded tab keep its peer identity and conflict-resolution
+# state instead of looking like a fresh peer to the network.
+idb = "0.6"
+js-sys = "0.3"
+wasm-bindgen = "0.2"
+serde-wasm-bindgen = "0.6"
 
 [target.'cfg(target_os = "android")'.dependencies]
 jni = { version = "0.21", optional = true }
@@ -62,3 +100,11 @@ dioxus = ["derive", "dep:dioxus", "dep:jni", "dep:ndk-context", "dep:objc2", "de
 # inside the crate is additionally gated by `#[cfg(target_os = "...")]`.
 push-sync = ["mobile-ffi", "dep:manganis", "dep:android_logger"]
 mobile-ffi = []
+# Browser/wasm32 build. Exposes pure-data modules (messages, conflict, auth,
+# protocol types, registry, network_status) so they can be linked from
+# Dioxus web apps. The libp2p-backed sync engine, sea-orm connection wrapper,
+# shadow tables, peer tracker, push helpers, and FFI surface are
+# `cfg(not(target_arch = "wasm32"))`-gated and unavailable in browser builds.
+# Browser-side P2P transports (WebSocket / WebRTC / WebTransport) are a
+# separate, future opt-in.
+web = []

--- a/wavesyncdb/src/dioxus/hooks.rs
+++ b/wavesyncdb/src/dioxus/hooks.rs
@@ -371,10 +371,8 @@ where
                     }
                     WriteKind::Insert => {
                         if let Some(cols) = &notif.column_values {
-                            let pairs: Vec<(String, serde_json::Value)> = cols
-                                .iter()
-                                .map(|(c, v)| (c.0.clone(), v.clone()))
-                                .collect();
+                            let pairs: Vec<(String, serde_json::Value)> =
+                                cols.iter().map(|(c, v)| (c.0.clone(), v.clone())).collect();
                             if let Some(model) =
                                 E::Model::wavesync_from_changes(&pk_column, &pk_str, &pairs)
                             {
@@ -492,10 +490,8 @@ where
                     }
                     WriteKind::Insert => {
                         if let Some(cols) = &notif.column_values {
-                            let pairs: Vec<(String, serde_json::Value)> = cols
-                                .iter()
-                                .map(|(c, v)| (c.0.clone(), v.clone()))
-                                .collect();
+                            let pairs: Vec<(String, serde_json::Value)> =
+                                cols.iter().map(|(c, v)| (c.0.clone(), v.clone())).collect();
                             if let Some(model) =
                                 E::Model::wavesync_from_changes(&pk_column, &pk_string, &pairs)
                             {

--- a/wavesyncdb/src/dioxus/mod.rs
+++ b/wavesyncdb/src/dioxus/mod.rs
@@ -40,7 +40,19 @@
 //! }
 //! ```
 
+// Native (non-wasm32) hooks built on top of SeaORM. These pull in
+// `sea_orm` types and a tokio multi-thread runtime, so they cannot
+// compile to wasm32. Browser apps get a parallel `web_hooks` module
+// below that exposes a similarly-shaped reactive API over
+// [`crate::WebSyncClient`] and [`crate::BrowserStore`].
+#[cfg(not(target_arch = "wasm32"))]
 pub mod hooks;
+#[cfg(not(target_arch = "wasm32"))]
 mod lifecycle;
-
+#[cfg(not(target_arch = "wasm32"))]
 pub use hooks::*;
+
+#[cfg(target_arch = "wasm32")]
+pub mod web_hooks;
+#[cfg(target_arch = "wasm32")]
+pub use web_hooks::*;

--- a/wavesyncdb/src/dioxus/web_hooks.rs
+++ b/wavesyncdb/src/dioxus/web_hooks.rs
@@ -1,0 +1,166 @@
+//! Dioxus reactive hooks for the browser sync engine.
+//!
+//! Mirrors what the WhatsApp-Web-style local-first apps do: IndexedDB
+//! is the single source of truth for application state, and components
+//! drive themselves off a reactive stream of changes.
+//!
+//! [`use_synced_table::<E>(client, table)`] returns a
+//! `Signal<Vec<E>>` that:
+//!
+//! 1. On the first render where `client` is `Some`, materializes the
+//!    full table from [`BrowserStore::list_table_rows`] — so reload
+//!    starts with whatever is persisted.
+//! 2. Subscribes to [`WebSyncClient::subscribe_resolved`] and folds
+//!    each `ColumnChange` into the in-memory `Vec<E>`. The engine
+//!    echoes local writes onto the same channel after `submit_local_write`
+//!    persists them, so a single subscription drives both local and
+//!    remote updates without the component needing optimistic-merge code.
+//! 3. Filters by table name so a single client can power multiple
+//!    independent table hooks.
+//!
+//! The companion [`WebSyncClient::submit`](crate::WebSyncClient::submit)
+//! is the writer: it takes a `&E`, serializes via
+//! [`BrowserEntity::to_columns`], and goes through `submit_local_write`.
+//! Components call `client.submit(&task).await` and get reactivity for
+//! free.
+
+use std::collections::HashMap;
+
+use dioxus::prelude::*;
+
+use crate::messages::ColumnChange;
+use crate::web_engine::WebSyncClient;
+use crate::web_entity::BrowserEntity;
+
+/// Reactive `Vec<E>` materialized from a synced table.
+///
+/// `client` is a `Signal<Option<WebSyncClient>>` rather than a
+/// `WebSyncClient` directly because the typical setup is to construct
+/// the client async and store it in a parent signal — `None` until the
+/// initial connect resolves. The hook waits internally for the first
+/// `Some`, then materializes from [`BrowserStore::list_table_rows`] and
+/// stays subscribed to changes for the rest of the component's
+/// lifetime.
+///
+/// `table` is captured by value (`String`) so the hook can use it from
+/// the spawned subscription task without lifetime gymnastics.
+pub fn use_synced_table<E: BrowserEntity>(
+    client: Signal<Option<WebSyncClient>>,
+    table: &'static str,
+) -> Signal<Vec<E>> {
+    let entities = use_signal(Vec::<E>::new);
+
+    use_effect({
+        let table = table.to_string();
+        let mut entities = entities;
+        move || {
+            // `use_effect` re-runs whenever any signal it reads changes.
+            // The only signal we read is `client`, which transitions
+            // None → Some exactly once in the typical setup, so the
+            // effect body fires once with a Some value. If something
+            // re-set client to None and back later, the effect would
+            // re-run and re-spawn the subscriber — that's fine; the old
+            // subscriber's task ends when the broadcast Receiver drops.
+            let Some(c) = client.read().clone() else {
+                return;
+            };
+            let table = table.clone();
+            spawn(async move {
+                // Materialize current state from the persisted shadow.
+                if let Some(store) = c.store() {
+                    match store.list_table_rows(&table).await {
+                        Ok(rows) => {
+                            let materialized: Vec<E> = rows
+                                .into_iter()
+                                .map(|r| E::from_columns(&r.pk, &r.columns))
+                                .collect();
+                            entities.set(materialized);
+                        }
+                        Err(e) => {
+                            log::warn!("use_synced_table({table}): list_table_rows failed: {e}");
+                        }
+                    }
+                }
+
+                // Stream subsequent changes into the same signal. The
+                // engine echoes local writes onto resolved_tx after
+                // persistence, so this single loop handles both local
+                // and remote updates uniformly.
+                let mut rx = c.subscribe_resolved();
+                loop {
+                    match rx.recv().await {
+                        Ok(change) => {
+                            if change.table.0 == table {
+                                apply_change_to::<E>(&mut entities, change);
+                            }
+                        }
+                        Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
+                            // Slow subscriber dropped messages. Recover
+                            // by re-materializing from the store, which
+                            // is authoritative.
+                            log::warn!("use_synced_table({table}): lagged {n}, re-materializing");
+                            if let Some(store) = c.store() {
+                                if let Ok(rows) = store.list_table_rows(&table).await {
+                                    entities.set(
+                                        rows.into_iter()
+                                            .map(|r| E::from_columns(&r.pk, &r.columns))
+                                            .collect(),
+                                    );
+                                }
+                            }
+                        }
+                        Err(tokio::sync::broadcast::error::RecvError::Closed) => {
+                            log::info!("use_synced_table({table}): client dropped");
+                            return;
+                        }
+                    }
+                }
+            });
+        }
+    });
+
+    entities
+}
+
+/// Fold a single `ColumnChange` into the materialized entity list.
+///
+/// Strategy: find the entity whose `pk` matches; if found, rebuild it
+/// by re-serializing the existing entity (`to_columns`), patching the
+/// affected column, and re-deserializing (`from_columns`). If not
+/// found, the change refers to a row this client hasn't seen before —
+/// build a fresh entity from the single column we just received. The
+/// missing-column slots get the entity's default values via
+/// `from_columns`'s `unwrap_or_default` pattern.
+///
+/// This handles the partial-update case (a single column edit on an
+/// existing row) and the new-row case (first column write for a
+/// previously unseen pk) without the caller having to special-case
+/// either. The cost is one round-trip through `to_columns` /
+/// `from_columns` per change — fine for interactive write rates.
+fn apply_change_to<E: BrowserEntity>(entities: &mut Signal<Vec<E>>, change: ColumnChange) {
+    let pk = change.pk.0;
+    let cid = change.cid.0;
+    let val = change.val;
+
+    entities.with_mut(|vec| {
+        if let Some(idx) = vec.iter().position(|e| e.pk() == pk) {
+            let mut cols: HashMap<String, serde_json::Value> =
+                vec[idx].to_columns().into_iter().collect();
+            match val {
+                Some(v) => {
+                    cols.insert(cid, v);
+                }
+                None => {
+                    cols.remove(&cid);
+                }
+            }
+            vec[idx] = E::from_columns(&pk, &cols);
+        } else {
+            let mut cols = HashMap::new();
+            if let Some(v) = val {
+                cols.insert(cid, v);
+            }
+            vec.push(E::from_columns(&pk, &cols));
+        }
+    });
+}

--- a/wavesyncdb/src/engine/mod.rs
+++ b/wavesyncdb/src/engine/mod.rs
@@ -748,15 +748,9 @@ impl EngineRunner {
         // `IfWatcher::new`. Binding to loopback skips the watcher path. The
         // same caution applies to QUIC's UDP socket setup.
         #[cfg(target_os = "ios")]
-        let (v4_quic, v6_quic) = (
-            "/ip4/127.0.0.1/udp/0/quic-v1",
-            "/ip6/::1/udp/0/quic-v1",
-        );
+        let (v4_quic, v6_quic) = ("/ip4/127.0.0.1/udp/0/quic-v1", "/ip6/::1/udp/0/quic-v1");
         #[cfg(not(target_os = "ios"))]
-        let (v4_quic, v6_quic) = (
-            "/ip4/0.0.0.0/udp/0/quic-v1",
-            "/ip6/::/udp/0/quic-v1",
-        );
+        let (v4_quic, v6_quic) = ("/ip4/0.0.0.0/udp/0/quic-v1", "/ip6/::/udp/0/quic-v1");
 
         log::info!("DIAG calling listen_on(QUIC)={v4_quic}");
         let t1 = std::time::Instant::now();
@@ -1208,17 +1202,30 @@ impl EngineRunner {
                     // otherwise libp2p would race only one address per peer
                     // and a NAT'd peer's direct address would lose to its
                     // circuit fallback that never got tried.
+                    //
+                    // Use the **last** `/p2p/` component, not the first.
+                    // For circuit-relay addresses
+                    // (`/.../p2p/<relay>/p2p-circuit/p2p/<dest>`) the first
+                    // is the relay and the last is the actual destination;
+                    // grouping by the first lumps every circuit address
+                    // for every dest into the relay's bucket, and
+                    // `dial_introduced_peer` then sees the relay peer-id,
+                    // observes we're already connected to it, and silently
+                    // drops the dial — circuit-relay addresses from
+                    // PeerList never reach libp2p.
                     let mut by_peer: std::collections::HashMap<libp2p::PeerId, Vec<String>> =
                         std::collections::HashMap::new();
                     for addr_str in &peers {
                         let Ok(addr) = addr_str.parse::<libp2p::Multiaddr>() else {
                             continue;
                         };
-                        let pid = addr.iter().find_map(|p| match p {
-                            libp2p::multiaddr::Protocol::P2p(pid) => Some(pid),
-                            _ => None,
-                        });
-                        if let Some(pid) = pid {
+                        let mut last_pid = None;
+                        for p in addr.iter() {
+                            if let libp2p::multiaddr::Protocol::P2p(pid) = p {
+                                last_pid = Some(pid);
+                            }
+                        }
+                        if let Some(pid) = last_pid {
                             by_peer.entry(pid).or_default().push(addr_str.clone());
                         }
                     }
@@ -1425,14 +1432,12 @@ mod tests {
         let a2: libp2p::Multiaddr = format!("/ip4/192.168.1.150/tcp/39981/p2p/{pid}")
             .parse()
             .unwrap();
-        let a3: libp2p::Multiaddr = format!(
-            "/ip4/77.37.125.212/tcp/4001/p2p/{pid}/p2p-circuit/p2p/{pid}"
-        )
-        .parse()
-        .unwrap();
+        let a3: libp2p::Multiaddr =
+            format!("/ip4/77.37.125.212/tcp/4001/p2p/{pid}/p2p-circuit/p2p/{pid}")
+                .parse()
+                .unwrap();
 
-        let (grouped, suffixless) =
-            group_bootstrap_addrs(vec![a1.clone(), a2.clone(), a3.clone()]);
+        let (grouped, suffixless) = group_bootstrap_addrs(vec![a1.clone(), a2.clone(), a3.clone()]);
 
         assert!(suffixless.is_empty());
         assert_eq!(grouped.len(), 1);
@@ -1470,12 +1475,10 @@ mod tests {
         let pid: libp2p::PeerId = "12D3KooWFnxFFxCm5ywp5j2WhBV4HbtCLDDh1jAr1QYa3xMtkAy3"
             .parse()
             .unwrap();
-        let with_pid: libp2p::Multiaddr = format!("/ip4/5.6.7.8/tcp/5678/p2p/{pid}")
-            .parse()
-            .unwrap();
+        let with_pid: libp2p::Multiaddr =
+            format!("/ip4/5.6.7.8/tcp/5678/p2p/{pid}").parse().unwrap();
 
-        let (grouped, suffixless) =
-            group_bootstrap_addrs(vec![bare.clone(), with_pid.clone()]);
+        let (grouped, suffixless) = group_bootstrap_addrs(vec![bare.clone(), with_pid.clone()]);
 
         assert_eq!(suffixless, vec![bare]);
         assert_eq!(grouped.len(), 1);

--- a/wavesyncdb/src/engine/relay_manager.rs
+++ b/wavesyncdb/src/engine/relay_manager.rs
@@ -391,11 +391,20 @@ impl EngineRunner {
             })
             .collect();
 
+        // Walk each multiaddr forward and keep the **last** `/p2p/<id>` —
+        // for a circuit-relay address (`/.../p2p/<relay>/p2p-circuit/p2p/<dest>`)
+        // the first /p2p/ is the relay, the last is the actual destination.
+        // Picking the first means every circuit address is mis-attributed
+        // to the relay we're already connected to, and the dial is
+        // silently dropped by the "already connected" guard below.
         let peer_id = addrs.iter().find_map(|a| {
-            a.iter().find_map(|p| match p {
-                libp2p::multiaddr::Protocol::P2p(pid) => Some(pid),
-                _ => None,
-            })
+            let mut last = None;
+            for p in a.iter() {
+                if let libp2p::multiaddr::Protocol::P2p(pid) = p {
+                    last = Some(pid);
+                }
+            }
+            last
         });
         let Some(peer_id) = peer_id else {
             log::warn!("Relay introduced peer with no /p2p/ suffix on any address");

--- a/wavesyncdb/src/lib.rs
+++ b/wavesyncdb/src/lib.rs
@@ -36,31 +36,68 @@
 //! - [`SyncChangeset`] — a batch of column-level CRDT changes sent over the network
 //! - [`ChangeNotification`] — lightweight event emitted after every write
 
+// Pure-data modules: types, conflict resolution, HMAC, protocol envelopes.
+// These compile on every target — including wasm32 — and form the surface
+// shared with browser builds.
 pub mod auth;
-pub mod background_sync;
 pub mod conflict;
-pub mod connection;
-pub mod engine;
-#[cfg(feature = "mobile-ffi")]
-mod ffi;
 pub mod messages;
 pub mod network_status;
-pub mod peer_tracker;
 pub mod protocol;
-pub(crate) mod push;
 pub mod registry;
-pub mod shadow;
 pub mod synced_model;
 
+// Native-only modules: anything that touches sea-orm (SQLite), libp2p
+// transports, tokio I/O, the local filesystem, or platform FFI. The
+// browser/wasm32 build skips all of these — a future browser sync path
+// (WebSocket/WebRTC/WebTransport + sqlite-wasm) will live behind its own
+// feature.
+#[cfg(not(target_arch = "wasm32"))]
+pub mod background_sync;
+#[cfg(not(target_arch = "wasm32"))]
+pub mod connection;
+#[cfg(not(target_arch = "wasm32"))]
+pub mod engine;
+#[cfg(all(not(target_arch = "wasm32"), feature = "mobile-ffi"))]
+mod ffi;
+#[cfg(not(target_arch = "wasm32"))]
+pub mod peer_tracker;
+#[cfg(not(target_arch = "wasm32"))]
+pub(crate) mod push;
+#[cfg(not(target_arch = "wasm32"))]
+pub mod shadow;
+
+// Browser/wasm32 engine. Minimal real-time changeset fan-out over a
+// WebSocket libp2p transport — see module docs for what's in scope and
+// what's deferred. Public API: [`web_engine::WebSyncClient`].
+#[cfg(target_arch = "wasm32")]
+pub mod web_engine;
+#[cfg(target_arch = "wasm32")]
+pub mod web_entity;
+#[cfg(target_arch = "wasm32")]
+pub mod web_store;
+#[cfg(target_arch = "wasm32")]
+pub use web_engine::{
+    LoopbackEnd, LoopbackLink, LoopbackPair, WebSyncClient, WebSyncError, WebSyncStatus,
+};
+#[cfg(target_arch = "wasm32")]
+pub use web_entity::BrowserEntity;
+#[cfg(target_arch = "wasm32")]
+pub use web_store::{BrowserStore, ResolvedRow, ShadowRow, StoreError};
+
 pub use auth::GroupKey;
+#[cfg(not(target_arch = "wasm32"))]
 pub use connection::{SchemaBuilder, SyncConfig, WaveSyncDb, WaveSyncDbBuilder};
+#[cfg(not(target_arch = "wasm32"))]
 pub use engine::EngineCommand;
 pub use messages::{
     AppId, ChangeNotification, ColumnChange, ColumnName, DeletePolicy, HmacTag, NodeId, PrimaryKey,
     SyncChangeset, TableName, TopicString, WriteKind,
 };
 pub use network_status::{NatStatus, NetworkEvent, NetworkStatus, PeerId, PeerInfo, RelayStatus};
-pub use registry::{SyncEntityInfo, TableMeta, TableRegistry};
+#[cfg(not(target_arch = "wasm32"))]
+pub use registry::SyncEntityInfo;
+pub use registry::{TableMeta, TableRegistry};
 pub use synced_model::SyncedModel;
 
 /// Returns recommended log module filter tuples for silencing noisy dependencies.
@@ -110,10 +147,20 @@ pub fn recommended_log_filters() -> Vec<(&'static str, log::LevelFilter)> {
     ]
 }
 
+/// The crate's semver version string (from `CARGO_PKG_VERSION`).
+///
+/// Available on every target — including wasm32 — so consumer crates (e.g.
+/// the documentation website) can render a single source of truth for the
+/// shipped version without re-declaring it.
+pub const VERSION: &str = env!("CARGO_PKG_VERSION");
+
 // Re-export for use by the #[derive(SyncEntity)] macro
 pub use inventory::submit as register_sync_entity;
 
-// Re-export sea-orm for users of the library
+// Re-export sea-orm for users of the library. sea-orm is not available on
+// wasm32 (sqlx-sqlite pulls in libsqlite3-sys, a C library), so this
+// re-export is gated to native targets. The `SyncEntity` derive uses it.
+#[cfg(not(target_arch = "wasm32"))]
 pub use sea_orm;
 
 // Re-export serde_json so the `SyncEntity` derive macro can reference it
@@ -121,7 +168,7 @@ pub use sea_orm;
 // declare serde_json as a direct dependency.
 pub use serde_json;
 
-#[cfg(feature = "derive")]
+#[cfg(all(feature = "derive", not(target_arch = "wasm32")))]
 pub use wavesyncdb_derive::SyncEntity;
 
 #[cfg(feature = "dioxus")]

--- a/wavesyncdb/src/registry.rs
+++ b/wavesyncdb/src/registry.rs
@@ -8,6 +8,7 @@
 use std::collections::HashMap;
 use std::sync::RwLock;
 
+#[cfg(not(target_arch = "wasm32"))]
 use sea_orm::DatabaseBackend;
 
 use crate::messages::DeletePolicy;
@@ -31,6 +32,11 @@ pub struct TableMeta {
 /// global [`inventory`] collection. [`WaveSyncDb::get_schema_registry`](crate::WaveSyncDb::get_schema_registry)
 /// iterates them to auto-discover entities whose `module_path` matches the
 /// given prefix.
+///
+/// Native-only: the `schema_fn` signature is typed against `sea_orm::DatabaseBackend`,
+/// and `sea-orm` is not available on wasm32 builds. Browser apps register
+/// table metadata directly via [`TableRegistry::register`].
+#[cfg(not(target_arch = "wasm32"))]
 pub struct SyncEntityInfo {
     /// The `module_path!()` of the entity, used for prefix matching.
     pub module_path: &'static str,
@@ -38,6 +44,7 @@ pub struct SyncEntityInfo {
     pub schema_fn: fn(DatabaseBackend) -> (String, TableMeta),
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 inventory::collect!(SyncEntityInfo);
 
 /// Registry of tables that participate in sync.

--- a/wavesyncdb/src/shadow.rs
+++ b/wavesyncdb/src/shadow.rs
@@ -106,9 +106,7 @@ async fn get_db_version_from_meta(db: &impl ConnectionTrait) -> Result<u64, DbEr
 /// table currently in the database. Discovered via `sqlite_master`, so
 /// this works correctly without prior knowledge of which entities are
 /// registered. Returns 0 when no shadow tables exist (fresh database).
-pub async fn max_db_version_across_shadow_tables(
-    db: &impl ConnectionTrait,
-) -> Result<u64, DbErr> {
+pub async fn max_db_version_across_shadow_tables(db: &impl ConnectionTrait) -> Result<u64, DbErr> {
     #[derive(Debug, FromQueryResult)]
     struct TableName {
         name: String,
@@ -228,9 +226,9 @@ pub async fn get_or_create_libp2p_keypair(
     }
 
     let keypair = libp2p::identity::Keypair::generate_ed25519();
-    let bytes = keypair.to_protobuf_encoding().map_err(|e| {
-        DbErr::Custom(format!("failed to encode libp2p keypair: {e}"))
-    })?;
+    let bytes = keypair
+        .to_protobuf_encoding()
+        .map_err(|e| DbErr::Custom(format!("failed to encode libp2p keypair: {e}")))?;
     db.execute_raw(Statement::from_sql_and_values(
         DatabaseBackend::Sqlite,
         "INSERT OR REPLACE INTO _wavesync_meta (key, value) VALUES ($1, $2)",

--- a/wavesyncdb/src/web_engine.rs
+++ b/wavesyncdb/src/web_engine.rs
@@ -1,0 +1,2275 @@
+//! Browser/wasm32 P2P engine — minimal real-time changeset fan-out with
+//! optional IndexedDB-backed persistence.
+//!
+//! This is a parallel, browser-only sibling to [`crate::engine`]. It shares
+//! the same wire format ([`SyncRequest::Push`] / [`SyncResponse::PushAck`],
+//! protocol id `/wavesync/snapshot/3.0.0`, length-prefixed serde_json) so a
+//! browser peer can talk to a native peer without protocol changes.
+//!
+//! ## Two flavours
+//!
+//! - [`WebSyncClient::connect`] — ephemeral. Identity, db_version, and
+//!   shadow state live in memory only. A reload starts fresh and looks
+//!   like a brand-new peer to the network.
+//! - [`WebSyncClient::connect_persistent`] — IndexedDB-backed. Identity is
+//!   restored on every reload (same `PeerId`), `db_version` is monotonic
+//!   across reloads, and incoming changes are conflict-resolved against
+//!   the persisted shadow table and only the winners are surfaced. This
+//!   is what enables real local-first apps.
+//!
+//! ## What persistence covers
+//!
+//! - **Identity** — a single ed25519 keypair is generated on first load
+//!   and persisted in the `meta` IndexedDB store. Subsequent reloads
+//!   restore it and present the same `PeerId` to the network.
+//! - **Local CRDT state** — every successful local write or accepted
+//!   remote change is written to the `shadow` store, keyed by
+//!   `(table, pk, cid)`. Conflict resolution on the next incoming change
+//!   sees the persisted state.
+//! - **Local db_version** — incremented on every local write and persisted
+//!   so version-vector catch-up (when added) starts from the right place.
+//!
+//! ## What persistence does NOT cover (yet)
+//!
+//! - **Application data.** The browser app owns its own data store
+//!   (IndexedDB rows, in-memory state, etc.). The engine emits resolved
+//!   `ColumnChange` events via [`WebSyncClient::subscribe_resolved`]; the
+//!   app applies them.
+//! - **Version-vector catch-up.** Per-peer `last_db_version` is written
+//!   but never read on this branch; a future revision will add the
+//!   request/response side.
+//! - **Tombstones / deletes.** Local writes go through `submit_local_write`,
+//!   which is insert/update only. Apps that need deletes can build a
+//!   `SyncChangeset` with `__deleted` columns by hand and call
+//!   [`WebSyncClient::publish`].
+
+use std::collections::{HashSet, VecDeque};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Duration;
+
+use futures::StreamExt;
+use libp2p::{
+    Multiaddr, PeerId as LibPeerId, Swarm, SwarmBuilder, identify, identity, noise, ping,
+    request_response,
+    swarm::{NetworkBehaviour, SwarmEvent},
+    yamux,
+};
+use tokio::sync::{Mutex, Notify, broadcast, mpsc, oneshot, watch};
+
+use crate::auth::GroupKey;
+use crate::conflict;
+use crate::messages::{ColumnChange, ColumnName, NodeId, PrimaryKey, SyncChangeset, TableName};
+use crate::protocol::{SyncRequest, SyncResponse};
+use crate::web_entity::BrowserEntity;
+use crate::web_store::{BrowserStore, ShadowRow};
+
+// Re-use the native engine's snapshot codec — same wire format, same
+// protocol id. Cargo gates engine/* away from wasm32, so we cannot pull
+// the codec from there. The codec is small (~80 LoC) and pure
+// `futures::AsyncRead/Write`, so we duplicate it here behind the wasm32
+// gate. Keeping the byte-for-byte protocol id `/wavesync/snapshot/3.0.0`
+// is what guarantees a browser client can talk to a native peer.
+mod snapshot_codec {
+    use std::io;
+
+    use async_trait::async_trait;
+    use futures::prelude::*;
+    use libp2p::StreamProtocol;
+    use libp2p::request_response;
+
+    use crate::protocol::{SyncRequest, SyncResponse};
+
+    pub const SNAPSHOT_PROTOCOL: StreamProtocol = StreamProtocol::new("/wavesync/snapshot/3.0.0");
+
+    #[derive(Debug, Clone, Default)]
+    pub struct SnapshotCodec;
+
+    #[async_trait]
+    impl request_response::Codec for SnapshotCodec {
+        type Protocol = StreamProtocol;
+        type Request = SyncRequest;
+        type Response = SyncResponse;
+
+        async fn read_request<T>(
+            &mut self,
+            _p: &Self::Protocol,
+            io: &mut T,
+        ) -> io::Result<Self::Request>
+        where
+            T: AsyncRead + Unpin + Send,
+        {
+            let bytes = read_lp(io).await?;
+            serde_json::from_slice(&bytes)
+                .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))
+        }
+
+        async fn read_response<T>(
+            &mut self,
+            _p: &Self::Protocol,
+            io: &mut T,
+        ) -> io::Result<Self::Response>
+        where
+            T: AsyncRead + Unpin + Send,
+        {
+            let bytes = read_lp(io).await?;
+            serde_json::from_slice(&bytes)
+                .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))
+        }
+
+        async fn write_request<T>(
+            &mut self,
+            _p: &Self::Protocol,
+            io: &mut T,
+            req: Self::Request,
+        ) -> io::Result<()>
+        where
+            T: AsyncWrite + Unpin + Send,
+        {
+            let bytes = serde_json::to_vec(&req)
+                .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+            write_lp(io, &bytes).await
+        }
+
+        async fn write_response<T>(
+            &mut self,
+            _p: &Self::Protocol,
+            io: &mut T,
+            res: Self::Response,
+        ) -> io::Result<()>
+        where
+            T: AsyncWrite + Unpin + Send,
+        {
+            let bytes = serde_json::to_vec(&res)
+                .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+            write_lp(io, &bytes).await
+        }
+    }
+
+    async fn read_lp<T: AsyncRead + Unpin>(io: &mut T) -> io::Result<Vec<u8>> {
+        let mut len_buf = [0u8; 4];
+        io.read_exact(&mut len_buf).await?;
+        let len = u32::from_be_bytes(len_buf) as usize;
+        if len > 64 * 1024 * 1024 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("payload too large: {len}"),
+            ));
+        }
+        let mut buf = vec![0u8; len];
+        io.read_exact(&mut buf).await?;
+        Ok(buf)
+    }
+
+    async fn write_lp<T: AsyncWrite + Unpin>(io: &mut T, data: &[u8]) -> io::Result<()> {
+        io.write_all(&(data.len() as u32).to_be_bytes()).await?;
+        io.write_all(data).await?;
+        io.flush().await
+    }
+}
+
+use snapshot_codec::{SNAPSHOT_PROTOCOL, SnapshotCodec};
+
+// Inline copy of `engine/push_protocol.rs` — needed here because
+// `engine/*` is gated to `not(target_arch = "wasm32")`. Wire shape MUST
+// stay byte-for-byte identical to the native version: protocol id
+// `/wavesync/push/1.0.0`, length-prefixed serde_json with a 1 MiB cap.
+// If `engine/push_protocol.rs` ever changes the wire format, this copy
+// must move in lockstep.
+mod push_codec {
+    use std::io;
+
+    use async_trait::async_trait;
+    use futures::prelude::*;
+    use libp2p::StreamProtocol;
+    use libp2p::request_response;
+    use serde::{Deserialize, Serialize};
+
+    pub const PUSH_PROTOCOL: StreamProtocol = StreamProtocol::new("/wavesync/push/1.0.0");
+
+    #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+    pub enum PushPlatform {
+        Fcm,
+        Apns,
+    }
+
+    #[derive(Debug, Clone, Serialize, Deserialize)]
+    pub enum PushRequest {
+        RegisterToken {
+            topic: String,
+            platform: PushPlatform,
+            token: String,
+        },
+        UnregisterToken {
+            topic: String,
+            token: String,
+        },
+        NotifyTopic {
+            topic: String,
+            sender_site_id: String,
+        },
+        AnnouncePresence {
+            topic: String,
+        },
+        PeerJoined {
+            topic: String,
+            peer_addrs: Vec<String>,
+        },
+    }
+
+    #[derive(Debug, Clone, Serialize, Deserialize)]
+    pub enum PushResponse {
+        Ok,
+        Error { message: String },
+        PeerList { peers: Vec<String> },
+    }
+
+    #[derive(Debug, Clone, Default)]
+    pub struct PushCodec;
+
+    #[async_trait]
+    impl request_response::Codec for PushCodec {
+        type Protocol = StreamProtocol;
+        type Request = PushRequest;
+        type Response = PushResponse;
+
+        async fn read_request<T>(
+            &mut self,
+            _p: &Self::Protocol,
+            io: &mut T,
+        ) -> io::Result<Self::Request>
+        where
+            T: AsyncRead + Unpin + Send,
+        {
+            let bytes = read_lp(io).await?;
+            serde_json::from_slice(&bytes)
+                .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))
+        }
+
+        async fn read_response<T>(
+            &mut self,
+            _p: &Self::Protocol,
+            io: &mut T,
+        ) -> io::Result<Self::Response>
+        where
+            T: AsyncRead + Unpin + Send,
+        {
+            let bytes = read_lp(io).await?;
+            serde_json::from_slice(&bytes)
+                .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))
+        }
+
+        async fn write_request<T>(
+            &mut self,
+            _p: &Self::Protocol,
+            io: &mut T,
+            req: Self::Request,
+        ) -> io::Result<()>
+        where
+            T: AsyncWrite + Unpin + Send,
+        {
+            let bytes = serde_json::to_vec(&req)
+                .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+            write_lp(io, &bytes).await
+        }
+
+        async fn write_response<T>(
+            &mut self,
+            _p: &Self::Protocol,
+            io: &mut T,
+            res: Self::Response,
+        ) -> io::Result<()>
+        where
+            T: AsyncWrite + Unpin + Send,
+        {
+            let bytes = serde_json::to_vec(&res)
+                .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+            write_lp(io, &bytes).await
+        }
+    }
+
+    async fn read_lp<T: AsyncRead + Unpin>(io: &mut T) -> io::Result<Vec<u8>> {
+        let mut len_buf = [0u8; 4];
+        io.read_exact(&mut len_buf).await?;
+        let len = u32::from_be_bytes(len_buf) as usize;
+        // Push messages are small — 1 MiB cap matches native.
+        if len > 1024 * 1024 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("push payload too large: {len}"),
+            ));
+        }
+        let mut buf = vec![0u8; len];
+        io.read_exact(&mut buf).await?;
+        Ok(buf)
+    }
+
+    async fn write_lp<T: AsyncWrite + Unpin>(io: &mut T, data: &[u8]) -> io::Result<()> {
+        io.write_all(&(data.len() as u32).to_be_bytes()).await?;
+        io.write_all(data).await?;
+        io.flush().await
+    }
+}
+
+use push_codec::{PUSH_PROTOCOL, PushCodec, PushRequest, PushResponse};
+
+/// Errors surfaced from the browser sync client.
+#[derive(Debug, thiserror::Error)]
+pub enum WebSyncError {
+    #[error("multiaddr parse failed: {0}")]
+    InvalidMultiaddr(String),
+    #[error("swarm setup failed: {0}")]
+    Setup(String),
+    #[error("dial failed: {0}")]
+    Dial(String),
+    #[error("client task is not running")]
+    NotRunning,
+    #[error("storage error: {0}")]
+    Store(String),
+    #[error("identity decode failed: {0}")]
+    Identity(String),
+}
+
+#[derive(NetworkBehaviour)]
+struct WebBehaviour {
+    snapshot: request_response::Behaviour<SnapshotCodec>,
+    push: request_response::Behaviour<PushCodec>,
+    relay_client: libp2p::relay::client::Behaviour,
+    identify: identify::Behaviour,
+    ping: ping::Behaviour,
+}
+
+enum Command {
+    /// Caller-built changeset — fan-out as-is. Used by apps that want to
+    /// build their own `SyncChangeset` (e.g. tombstones).
+    Publish(SyncChangeset),
+    /// High-level local write — engine bumps `db_version` and per-column
+    /// `col_version`, persists to shadow, then broadcasts. The new
+    /// `db_version` is delivered back via `ack`.
+    SubmitLocal {
+        table: String,
+        pk: String,
+        columns: Vec<(String, serde_json::Value)>,
+        ack: oneshot::Sender<Result<u64, WebSyncError>>,
+    },
+}
+
+/// Browser-side sync client.
+///
+/// Cheap to clone — internally a pair of channel senders. All clones share
+/// the same underlying swarm task, which runs forever via
+/// [`wasm_bindgen_futures::spawn_local`] until the last clone is dropped.
+#[derive(Clone)]
+pub struct WebSyncClient {
+    cmd_tx: mpsc::UnboundedSender<Command>,
+    inbound_tx: broadcast::Sender<SyncChangeset>,
+    resolved_tx: broadcast::Sender<ColumnChange>,
+    /// `None` for ephemeral clients — keeps the public type uniform.
+    store: Option<Arc<BrowserStore>>,
+    /// Live snapshot of "what does the engine see right now" — peer
+    /// list, relay-connected flag. The engine task pushes a fresh
+    /// snapshot on every connection lifecycle event. UIs subscribe via
+    /// [`Self::subscribe_status`]. `watch` (not `broadcast`) because
+    /// the latest value is what matters; subscribers that fall behind
+    /// just get the most recent value next time they read.
+    status_rx: watch::Receiver<WebSyncStatus>,
+}
+
+/// Live debug snapshot exposed by [`WebSyncClient::subscribe_status`].
+///
+/// Each field updates on its own rhythm:
+/// - `connected_peer_ids` and `relay_connected` change on every
+///   `ConnectionEstablished` / `ConnectionClosed` swarm event.
+/// - `local_peer_id` is set once at startup.
+/// - `relay_peer_id` is set once at startup if the client was built
+///   via `connect_via_relay`.
+#[derive(Debug, Clone, Default)]
+pub struct WebSyncStatus {
+    pub local_peer_id: String,
+    pub relay_peer_id: Option<String>,
+    pub relay_connected: bool,
+    pub connected_peer_ids: Vec<String>,
+}
+
+impl WebSyncClient {
+    /// Build an **ephemeral** client and dial `peer_multiaddr` over WebSocket.
+    ///
+    /// Identity, `db_version`, and shadow state live in memory only.
+    /// Reload = fresh peer. Use [`Self::connect_persistent`] if you want
+    /// a stable `PeerId` and CRDT continuity across reloads.
+    pub fn connect(
+        peer_multiaddr: &str,
+        user_topic: &str,
+        passphrase: Option<&str>,
+    ) -> Result<Self, WebSyncError> {
+        let keypair = identity::Keypair::generate_ed25519();
+        let site_id = NodeId(rand_site_id());
+        Self::start(
+            peer_multiaddr,
+            user_topic,
+            passphrase,
+            keypair,
+            site_id,
+            0,
+            None,
+            None, // not relay-mediated discovery
+        )
+    }
+
+    /// Build a **persistent** client. Restores or initializes IndexedDB
+    /// state in `wavesync-<store_name>`.
+    ///
+    /// Async because the IndexedDB open + read transactions are async.
+    /// On first call, generates a fresh keypair and `site_id`, persists
+    /// them, and starts at `db_version=0`. On subsequent calls (same
+    /// `store_name`), restores the persisted identity so the network sees
+    /// the same `PeerId` as before.
+    pub async fn connect_persistent(
+        peer_multiaddr: &str,
+        user_topic: &str,
+        passphrase: Option<&str>,
+        store_name: &str,
+    ) -> Result<Self, WebSyncError> {
+        let store = BrowserStore::open(store_name)
+            .await
+            .map_err(|e| WebSyncError::Store(e.to_string()))?;
+
+        let keypair = match store
+            .get_keypair()
+            .await
+            .map_err(|e| WebSyncError::Store(e.to_string()))?
+        {
+            Some(bytes) => identity::Keypair::from_protobuf_encoding(&bytes)
+                .map_err(|e| WebSyncError::Identity(e.to_string()))?,
+            None => {
+                let kp = identity::Keypair::generate_ed25519();
+                let bytes = kp
+                    .to_protobuf_encoding()
+                    .map_err(|e| WebSyncError::Identity(e.to_string()))?;
+                store
+                    .put_keypair(&bytes)
+                    .await
+                    .map_err(|e| WebSyncError::Store(e.to_string()))?;
+                kp
+            }
+        };
+
+        let site_id = match store
+            .get_site_id()
+            .await
+            .map_err(|e| WebSyncError::Store(e.to_string()))?
+        {
+            Some(id) => id,
+            None => {
+                let id = NodeId(rand_site_id());
+                store
+                    .put_site_id(&id)
+                    .await
+                    .map_err(|e| WebSyncError::Store(e.to_string()))?;
+                id
+            }
+        };
+
+        let db_version = store
+            .get_db_version()
+            .await
+            .map_err(|e| WebSyncError::Store(e.to_string()))?;
+
+        Self::start(
+            peer_multiaddr,
+            user_topic,
+            passphrase,
+            keypair,
+            site_id,
+            db_version,
+            Some(Arc::new(store)),
+            None, // not relay-mediated discovery
+        )
+    }
+
+    /// Build a persistent client that connects through a relay for
+    /// peer discovery — the WhatsApp-Web-style topology.
+    ///
+    /// `relay_addr` must be a fully-qualified multiaddr including the
+    /// `/p2p/<relay-peer-id>` suffix, e.g.
+    /// `/ip4/127.0.0.1/tcp/4002/ws/p2p/12D3KooW…`. The client:
+    ///
+    /// 1. Dials the relay over WebSocket.
+    /// 2. On connection establish, sends `PushRequest::AnnouncePresence
+    ///    { topic }`. The relay responds with `PushResponse::PeerList`
+    ///    of circuit-relay multiaddrs for every other peer on the same
+    ///    topic. The client dials each.
+    /// 3. Stays subscribed to inbound `PushRequest::PeerJoined` from
+    ///    the relay so newly-arriving peers get dialed too.
+    /// 4. Sync flows over the discovered peer connections (direct or
+    ///    circuit-relayed depending on what's reachable).
+    ///
+    /// Identity (keypair + site_id + db_version) is persisted to
+    /// IndexedDB at `wavesync-<store_name>` exactly like
+    /// [`Self::connect_persistent`].
+    ///
+    /// Note on browser security: when the demo is served over HTTPS,
+    /// browsers block plain `ws://` connections (mixed-content). The
+    /// `relay_addr` must use `wss://` (terminated at a reverse proxy)
+    /// or the demo must be served over HTTP for development.
+    pub async fn connect_via_relay(
+        relay_addr: &str,
+        user_topic: &str,
+        passphrase: Option<&str>,
+        store_name: &str,
+    ) -> Result<Self, WebSyncError> {
+        // Parse the relay multiaddr early so we fail fast on malformed
+        // input, and extract the peer-id so the engine can recognize
+        // "this connection is to the relay" later.
+        let parsed: Multiaddr = relay_addr
+            .parse()
+            .map_err(|e: libp2p::multiaddr::Error| WebSyncError::InvalidMultiaddr(e.to_string()))?;
+        let relay_peer_id = peer_id_from_multiaddr(&parsed).ok_or_else(|| {
+            WebSyncError::InvalidMultiaddr("relay multiaddr must end in /p2p/<peer-id>".into())
+        })?;
+
+        let store = BrowserStore::open(store_name)
+            .await
+            .map_err(|e| WebSyncError::Store(e.to_string()))?;
+
+        let keypair = match store
+            .get_keypair()
+            .await
+            .map_err(|e| WebSyncError::Store(e.to_string()))?
+        {
+            Some(bytes) => identity::Keypair::from_protobuf_encoding(&bytes)
+                .map_err(|e| WebSyncError::Identity(e.to_string()))?,
+            None => {
+                let kp = identity::Keypair::generate_ed25519();
+                let bytes = kp
+                    .to_protobuf_encoding()
+                    .map_err(|e| WebSyncError::Identity(e.to_string()))?;
+                store
+                    .put_keypair(&bytes)
+                    .await
+                    .map_err(|e| WebSyncError::Store(e.to_string()))?;
+                kp
+            }
+        };
+
+        let site_id = match store
+            .get_site_id()
+            .await
+            .map_err(|e| WebSyncError::Store(e.to_string()))?
+        {
+            Some(id) => id,
+            None => {
+                let id = NodeId(rand_site_id());
+                store
+                    .put_site_id(&id)
+                    .await
+                    .map_err(|e| WebSyncError::Store(e.to_string()))?;
+                id
+            }
+        };
+
+        let db_version = store
+            .get_db_version()
+            .await
+            .map_err(|e| WebSyncError::Store(e.to_string()))?;
+
+        Self::start(
+            relay_addr,
+            user_topic,
+            passphrase,
+            keypair,
+            site_id,
+            db_version,
+            Some(Arc::new(store)),
+            Some(relay_peer_id),
+        )
+    }
+
+    fn start(
+        peer_multiaddr: &str,
+        user_topic: &str,
+        passphrase: Option<&str>,
+        keypair: identity::Keypair,
+        site_id: NodeId,
+        db_version: u64,
+        store: Option<Arc<BrowserStore>>,
+        // When `Some`, treat the dialed multiaddr as a relay rather
+        // than a sync peer: send AnnouncePresence on connect, accept
+        // PeerJoined inbounds from this peer-id only, and exclude this
+        // peer from snapshot-Push fan-out. `None` keeps the legacy
+        // single-peer-dial behavior used by `connect_persistent` and
+        // `connect`.
+        relay_peer_id: Option<LibPeerId>,
+    ) -> Result<Self, WebSyncError> {
+        let group_key = passphrase.map(GroupKey::from_passphrase);
+        let effective_topic = group_key
+            .as_ref()
+            .map(|gk| gk.derive_topic(user_topic))
+            .unwrap_or_else(|| user_topic.to_string());
+
+        let target: Multiaddr = peer_multiaddr
+            .parse()
+            .map_err(|e: libp2p::multiaddr::Error| WebSyncError::InvalidMultiaddr(e.to_string()))?;
+
+        let local_peer_id = keypair.public().to_peer_id();
+
+        // `with_other_transport`'s closure must return either a bare
+        // Transport or a `Result<T, Box<dyn Error + Send + Sync>>` — the
+        // two `TryIntoTransport` impls in libp2p 0.56. Anything else
+        // (incl. our own error type) compile-fails with a confusing
+        // `Result<...>: Transport not satisfied` error. Box noise errors
+        // explicitly to land in the documented happy path.
+        // The `.with_relay_client(...)` step after `with_other_transport`
+        // wraps our base WebSocket transport with libp2p's circuit-relay
+        // client. After that, `swarm.dial(/p2p/<relay>/p2p-circuit/p2p/<peer>)`
+        // is routable — the relay-client transport handles the inner hop.
+        // Without this step those dials fail with an unrouted-address
+        // error. The `with_behaviour` closure now receives `(key,
+        // relay_client)` so the produced `relay_client::Behaviour` is
+        // wired into our `WebBehaviour`.
+        let mut swarm = SwarmBuilder::with_existing_identity(keypair)
+            .with_wasm_bindgen()
+            .with_other_transport(|key| {
+                use libp2p::Transport;
+                use libp2p::core::upgrade::Version;
+                let ws = libp2p::websocket_websys::Transport::default();
+                let auth = noise::Config::new(key)
+                    .map_err(|e| Box::new(e) as Box<dyn std::error::Error + Send + Sync>)?;
+                Ok::<_, Box<dyn std::error::Error + Send + Sync>>(
+                    ws.upgrade(Version::V1)
+                        .authenticate(auth)
+                        .multiplex(yamux::Config::default()),
+                )
+            })
+            .map_err(|e| WebSyncError::Setup(format!("transport: {e}")))?
+            .with_relay_client(noise::Config::new, yamux::Config::default)
+            .map_err(|e| WebSyncError::Setup(format!("relay client: {e}")))?
+            .with_behaviour(|key, relay_client| WebBehaviour {
+                snapshot: request_response::Behaviour::new(
+                    [(SNAPSHOT_PROTOCOL, request_response::ProtocolSupport::Full)],
+                    request_response::Config::default(),
+                ),
+                push: request_response::Behaviour::new(
+                    [(PUSH_PROTOCOL, request_response::ProtocolSupport::Full)],
+                    request_response::Config::default(),
+                ),
+                relay_client,
+                identify: identify::Behaviour::new(identify::Config::new(
+                    "/wavesync/2.0.0".into(),
+                    key.public(),
+                )),
+                ping: ping::Behaviour::default(),
+            })
+            .map_err(|e| WebSyncError::Setup(format!("behaviour: {e}")))?
+            // Default in libp2p 0.55+ is 10 seconds — far too short for a
+            // relay connection that may be idle between announces while no
+            // peers exist on the topic. The browser would close the relay
+            // connection 10s after the AnnouncePresence round-trip,
+            // re-dial, repeat. Match the relay's 5-minute default so the
+            // connection stays up across quiet periods. Ping
+            // (`ping::Behaviour::default()` interval = 15s) keeps it
+            // measurably alive within that window.
+            .with_swarm_config(|cfg| cfg.with_idle_connection_timeout(Duration::from_secs(300)))
+            .build();
+
+        swarm
+            .dial(target.clone())
+            .map_err(|e| WebSyncError::Dial(e.to_string()))?;
+
+        let (cmd_tx, cmd_rx) = mpsc::unbounded_channel();
+        let (inbound_tx, _) = broadcast::channel(64);
+        let (resolved_tx, _) = broadcast::channel(256);
+        let (status_tx, status_rx) = watch::channel(WebSyncStatus {
+            local_peer_id: local_peer_id.to_string(),
+            relay_peer_id: relay_peer_id.map(|p| p.to_string()),
+            relay_connected: false,
+            connected_peer_ids: Vec::new(),
+        });
+
+        log::info!(
+            "WebSyncClient: peer {local_peer_id}, dialing {target}, topic={effective_topic}, persistent={}",
+            store.is_some()
+        );
+
+        let state = EngineState {
+            site_id,
+            db_version: Arc::new(Mutex::new(db_version)),
+            topic: effective_topic,
+            group_key,
+            store: store.clone(),
+            inbound_tx: inbound_tx.clone(),
+            resolved_tx: resolved_tx.clone(),
+            relay_peer_id,
+            status_tx,
+        };
+
+        wasm_bindgen_futures::spawn_local(run_swarm(swarm, cmd_rx, state));
+
+        Ok(Self {
+            cmd_tx,
+            inbound_tx,
+            resolved_tx,
+            store,
+            status_rx,
+        })
+    }
+
+    /// Broadcast a caller-built changeset to all currently connected peers.
+    ///
+    /// This is the low-level escape hatch for apps that want to construct
+    /// `SyncChangeset` themselves (e.g. for tombstones / deletes). For
+    /// regular inserts and updates use [`Self::submit_local_write`].
+    pub fn publish(&self, changeset: SyncChangeset) -> Result<(), WebSyncError> {
+        self.cmd_tx
+            .send(Command::Publish(changeset))
+            .map_err(|_| WebSyncError::NotRunning)
+    }
+
+    /// High-level local write.
+    ///
+    /// Looks up the current shadow entry for each `(table, pk, column)`,
+    /// bumps `col_version`, persists the new shadow row, increments
+    /// `db_version`, and broadcasts the resulting `SyncChangeset` to all
+    /// connected peers. Returns the new `db_version`.
+    ///
+    /// Persistent clients durably commit the new shadow rows and
+    /// `db_version` to IndexedDB before the broadcast — a peer that
+    /// receives this changeset and later sends back catch-up traffic
+    /// will see consistent state. Ephemeral clients keep all of this in
+    /// memory.
+    pub async fn submit_local_write(
+        &self,
+        table: &str,
+        pk: &str,
+        columns: Vec<(String, serde_json::Value)>,
+    ) -> Result<u64, WebSyncError> {
+        let (tx, rx) = oneshot::channel();
+        self.cmd_tx
+            .send(Command::SubmitLocal {
+                table: table.to_string(),
+                pk: pk.to_string(),
+                columns,
+                ack: tx,
+            })
+            .map_err(|_| WebSyncError::NotRunning)?;
+        rx.await.map_err(|_| WebSyncError::NotRunning)?
+    }
+
+    /// Type-safe wrapper around [`Self::submit_local_write`].
+    ///
+    /// Apps implement [`BrowserEntity`] for their domain types and call
+    /// `client.submit(&task).await` instead of building the column bag
+    /// by hand. This is the path the reactive
+    /// [`use_synced_table`](crate::dioxus::use_synced_table) hook takes
+    /// internally; using it consistently means local edits flow through
+    /// the same channel remote ones do, so reactive subscribers don't
+    /// need a special optimistic-update path.
+    pub async fn submit<E: BrowserEntity>(
+        &self,
+        table: &str,
+        entity: &E,
+    ) -> Result<u64, WebSyncError> {
+        let pk = entity.pk();
+        let columns = entity.to_columns();
+        self.submit_local_write(table, &pk, columns).await
+    }
+
+    /// Subscribe to **raw** incoming changesets from peers.
+    ///
+    /// Each received message arrives whole, **before** local conflict
+    /// resolution. Useful if the app wants to inspect the wire format
+    /// directly or implement its own resolution. Most apps want
+    /// [`Self::subscribe_resolved`] instead.
+    pub fn subscribe(&self) -> broadcast::Receiver<SyncChangeset> {
+        self.inbound_tx.subscribe()
+    }
+
+    /// Subscribe to per-column changes the engine has committed to its
+    /// shadow store.
+    ///
+    /// Fires for **both** local writes (echoed after `submit_local_write`
+    /// persists) and remote pushes (after they win conflict resolution).
+    /// Reactive UIs can drive themselves entirely off this single stream
+    /// without needing to special-case the optimistic-update path.
+    /// Apps that genuinely want only-remote events can filter by
+    /// `site_id != my_site_id`.
+    pub fn subscribe_resolved(&self) -> broadcast::Receiver<ColumnChange> {
+        self.resolved_tx.subscribe()
+    }
+
+    /// `true` if this client is backed by IndexedDB persistence.
+    pub fn is_persistent(&self) -> bool {
+        self.store.is_some()
+    }
+
+    /// Access the underlying [`BrowserStore`] for direct reads.
+    ///
+    /// `None` when the client was constructed via [`Self::connect`]
+    /// (ephemeral). The store is what application UIs use to materialize
+    /// initial state on mount via `list_table_rows`.
+    pub fn store(&self) -> Option<Arc<BrowserStore>> {
+        self.store.clone()
+    }
+
+    /// Connect via an in-process loopback channel. **Demo/test path only.**
+    ///
+    /// Two clients constructed with [`LoopbackPair::new`] and crossed
+    /// channel ends exchange `SyncRequest::Push` envelopes directly,
+    /// bypassing libp2p entirely. All the engine logic that matters —
+    /// HMAC, topic check, conflict resolution against the persisted
+    /// shadow, broadcast of resolved changes — still runs. What's
+    /// skipped is the network: no swarm, no transport, no peer ID.
+    ///
+    /// This exists so the website can ship a self-contained demo that
+    /// shows two independent peers with their own IndexedDB stores
+    /// syncing in real time without the user needing to run a relay.
+    /// Production apps should use [`Self::connect_persistent`] or
+    /// [`Self::connect`].
+    pub async fn connect_loopback(
+        end: LoopbackEnd,
+        user_topic: &str,
+        passphrase: Option<&str>,
+        store_name: &str,
+    ) -> Result<Self, WebSyncError> {
+        let store = BrowserStore::open(store_name)
+            .await
+            .map_err(|e| WebSyncError::Store(e.to_string()))?;
+
+        // Same identity-restore logic as connect_persistent. The
+        // loopback transport doesn't need the libp2p keypair (no peer
+        // negotiation), but persisting one keeps `site_id` stable across
+        // reloads and means swapping a loopback client for a real
+        // network one later wouldn't change identity.
+        let _kp = match store
+            .get_keypair()
+            .await
+            .map_err(|e| WebSyncError::Store(e.to_string()))?
+        {
+            Some(bytes) => identity::Keypair::from_protobuf_encoding(&bytes)
+                .map_err(|e| WebSyncError::Identity(e.to_string()))?,
+            None => {
+                let kp = identity::Keypair::generate_ed25519();
+                let bytes = kp
+                    .to_protobuf_encoding()
+                    .map_err(|e| WebSyncError::Identity(e.to_string()))?;
+                store
+                    .put_keypair(&bytes)
+                    .await
+                    .map_err(|e| WebSyncError::Store(e.to_string()))?;
+                kp
+            }
+        };
+
+        let site_id = match store
+            .get_site_id()
+            .await
+            .map_err(|e| WebSyncError::Store(e.to_string()))?
+        {
+            Some(id) => id,
+            None => {
+                let id = NodeId(rand_site_id());
+                store
+                    .put_site_id(&id)
+                    .await
+                    .map_err(|e| WebSyncError::Store(e.to_string()))?;
+                id
+            }
+        };
+
+        let db_version = store
+            .get_db_version()
+            .await
+            .map_err(|e| WebSyncError::Store(e.to_string()))?;
+
+        let group_key = passphrase.map(GroupKey::from_passphrase);
+        let effective_topic = group_key
+            .as_ref()
+            .map(|gk| gk.derive_topic(user_topic))
+            .unwrap_or_else(|| user_topic.to_string());
+
+        let (cmd_tx, cmd_rx) = mpsc::unbounded_channel();
+        let (inbound_tx, _) = broadcast::channel(64);
+        let (resolved_tx, _) = broadcast::channel(256);
+        let (status_tx, status_rx) = watch::channel(WebSyncStatus {
+            local_peer_id: format!("loopback-{:02x?}", &site_id.0[..4]),
+            relay_peer_id: None,
+            relay_connected: false,
+            connected_peer_ids: Vec::new(),
+        });
+
+        log::info!(
+            "WebSyncClient (loopback): site_id={:02x?}, topic={effective_topic}, store={store_name}",
+            &site_id.0[..4]
+        );
+
+        let store_arc = Arc::new(store);
+        let state = EngineState {
+            site_id,
+            db_version: Arc::new(Mutex::new(db_version)),
+            topic: effective_topic,
+            group_key,
+            store: Some(store_arc.clone()),
+            inbound_tx: inbound_tx.clone(),
+            resolved_tx: resolved_tx.clone(),
+            relay_peer_id: None, // loopback transport has no notion of a relay
+            status_tx,
+        };
+
+        wasm_bindgen_futures::spawn_local(run_loopback(end, cmd_rx, state));
+
+        Ok(Self {
+            cmd_tx,
+            inbound_tx,
+            resolved_tx,
+            store: Some(store_arc),
+            status_rx,
+        })
+    }
+
+    /// Live-updating debug status: connected peer ids, relay
+    /// connection flag. Subscribers see the most recent snapshot
+    /// immediately and a fresh snapshot on every connection
+    /// lifecycle event. UIs typically use a Dioxus
+    /// `Signal<WebSyncStatus>` driven by this receiver.
+    pub fn subscribe_status(&self) -> watch::Receiver<WebSyncStatus> {
+        self.status_rx.clone()
+    }
+}
+
+/// One end of an in-process loopback transport. See
+/// [`LoopbackPair::new`] / [`WebSyncClient::connect_loopback`].
+pub struct LoopbackEnd {
+    out_tx: mpsc::UnboundedSender<SyncRequest>,
+    in_rx: mpsc::UnboundedReceiver<SyncRequest>,
+    link: LoopbackLink,
+}
+
+impl LoopbackEnd {
+    /// Cloneable handle for toggling this side's online state from
+    /// outside the engine task.
+    pub fn link(&self) -> LoopbackLink {
+        self.link.clone()
+    }
+}
+
+/// External handle for an [`LoopbackEnd`]'s online state.
+///
+/// Cheap to clone — internally an `Arc<AtomicBool>` and an
+/// `Arc<Notify>`. Calling [`Self::set_online`] toggles message delivery
+/// for that side: while offline, the engine task buffers both
+/// outgoing and incoming `SyncRequest`s. Going back online drains
+/// both buffers in order, which is what makes "edit while disconnected,
+/// reconnect, see it sync" work for free in the demo.
+#[derive(Clone)]
+pub struct LoopbackLink {
+    online: Arc<AtomicBool>,
+    notify: Arc<Notify>,
+}
+
+impl LoopbackLink {
+    fn new() -> Self {
+        Self {
+            online: Arc::new(AtomicBool::new(true)),
+            notify: Arc::new(Notify::new()),
+        }
+    }
+
+    /// Whether this side is currently delivering messages.
+    pub fn is_online(&self) -> bool {
+        self.online.load(Ordering::Relaxed)
+    }
+
+    /// Toggle online state. Wakes the engine task so any backlog drains
+    /// (when going online) or so subsequent traffic starts buffering
+    /// (when going offline).
+    pub fn set_online(&self, online: bool) {
+        self.online.store(online, Ordering::Relaxed);
+        self.notify.notify_one();
+    }
+}
+
+/// A pair of [`LoopbackEnd`]s wired together. Pass `pair.a` to one
+/// client and `pair.b` to the other, and they will sync via in-process
+/// channels. Grab `pair.a.link()` / `pair.b.link()` *before* moving
+/// each end into [`WebSyncClient::connect_loopback`] if you want to
+/// toggle either side offline later.
+pub struct LoopbackPair {
+    pub a: LoopbackEnd,
+    pub b: LoopbackEnd,
+}
+
+impl Default for LoopbackPair {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl LoopbackPair {
+    /// Create a fresh pair of crossed channels. Each end starts in the
+    /// online state.
+    pub fn new() -> Self {
+        let (a_to_b, b_in) = mpsc::unbounded_channel::<SyncRequest>();
+        let (b_to_a, a_in) = mpsc::unbounded_channel::<SyncRequest>();
+        Self {
+            a: LoopbackEnd {
+                out_tx: a_to_b,
+                in_rx: a_in,
+                link: LoopbackLink::new(),
+            },
+            b: LoopbackEnd {
+                out_tx: b_to_a,
+                in_rx: b_in,
+                link: LoopbackLink::new(),
+            },
+        }
+    }
+}
+
+struct EngineState {
+    site_id: NodeId,
+    db_version: Arc<Mutex<u64>>,
+    topic: String,
+    group_key: Option<GroupKey>,
+    store: Option<Arc<BrowserStore>>,
+    inbound_tx: broadcast::Sender<SyncChangeset>,
+    resolved_tx: broadcast::Sender<ColumnChange>,
+    /// PeerId of the relay we dialed via `connect_via_relay`. Used to:
+    /// (1) trigger an `AnnouncePresence` when this specific peer
+    /// connects, (2) skip the relay when fan-outing snapshot Push
+    /// messages — it's not a sync peer, and (3) validate inbound
+    /// `PushRequest::PeerJoined` (only the relay is allowed to announce
+    /// peer joins, otherwise any peer could trick us into dialing
+    /// arbitrary addresses). `None` for `connect`/`connect_persistent`/
+    /// `connect_loopback` clients that aren't using relay-mediated
+    /// discovery.
+    relay_peer_id: Option<LibPeerId>,
+    /// Watch channel sender for live debug status. Engine pushes a
+    /// fresh `WebSyncStatus` after every connection lifecycle event;
+    /// UIs read it via [`WebSyncClient::subscribe_status`].
+    status_tx: watch::Sender<WebSyncStatus>,
+}
+
+/// Recompute the watch-channel snapshot from the current connected
+/// set + relay-known state. Cheap (a clone of a small Vec); called on
+/// every `ConnectionEstablished`/`ConnectionClosed` so UIs see peer
+/// list changes within one event loop tick.
+///
+/// `relay_connected` is tracked separately because the relay peer-id
+/// is *not* inserted into `connected` (the relay isn't a sync peer
+/// and shouldn't see snapshot fan-out) — so we can't derive its
+/// connection state from the set.
+fn push_status(state: &EngineState, connected: &HashSet<LibPeerId>, relay_connected: bool) {
+    let connected_peer_ids = connected.iter().map(|p| p.to_string()).collect();
+    // Snapshot the immutable fields (local + relay peer ids) into owned
+    // values *before* calling `send_replace`. Inlining `borrow()` into
+    // the `send_replace` argument list keeps the read-guard alive across
+    // the write attempt, which races against the watch's internal lock.
+    let (local_peer_id, relay_peer_id) = {
+        let snap = state.status_tx.borrow();
+        (snap.local_peer_id.clone(), snap.relay_peer_id.clone())
+    };
+    // `send_replace` doesn't error on no-subscribers (unlike
+    // `broadcast::send`'s SendError) and it overwrites the latest
+    // value, which is exactly what watch consumers want.
+    state.status_tx.send_replace(WebSyncStatus {
+        local_peer_id,
+        relay_peer_id,
+        relay_connected,
+        connected_peer_ids,
+    });
+}
+
+/// Loopback variant of [`run_swarm`]. No libp2p — `SyncRequest`s flow
+/// through the `LoopbackEnd` channels directly. Used by the website
+/// demo to show two independent engines syncing inside a single page.
+///
+/// Honors the [`LoopbackLink`] online flag. While offline:
+/// - outgoing requests (from local writes) buffer in `pending_out`
+/// - incoming requests (the peer can still write to the channel; we just
+///   don't deliver them) buffer in `pending_in`
+///
+/// On the online → offline transition there's nothing to do beyond
+/// flipping the flag. On offline → online, both buffers drain in FIFO
+/// order: outgoing first (so the peer sees the local edits), then
+/// incoming (so we see the peer's edits). The order doesn't actually
+/// matter for convergence — CRDT resolution is order-independent — but
+/// "show my own writes hitting the peer first" is the more intuitive
+/// demo behavior.
+/// Stable key under which each loopback engine records "what's the
+/// highest db_version I've seen from my counterpart." Loopback always
+/// has exactly one peer per pair, so we don't bother keying by site_id
+/// (which would require knowing the peer's site_id ahead of time).
+const LOOPBACK_PEER_KEY: &str = "loopback-peer";
+
+async fn run_loopback(
+    mut end: LoopbackEnd,
+    mut cmd_rx: mpsc::UnboundedReceiver<Command>,
+    state: EngineState,
+) {
+    let mut pending_out: VecDeque<SyncRequest> = VecDeque::new();
+    let link = end.link.clone();
+    // Force a catch-up on the very first iteration: even though the link
+    // starts in the "online" state, our peer_versions store may have
+    // entries from a previous session — or the peer may have made local
+    // edits before we ran. Treating the first iteration as an offline →
+    // online transition pulls in anything we missed.
+    let mut was_online = false;
+
+    loop {
+        let now_online = link.is_online();
+        if now_online && !was_online {
+            // offline → online transition (or initial connect). Drain any
+            // local edits we made while disconnected, then ask the peer
+            // for everything they have past our last seen db_version.
+            // This is the version-vector catch-up — same protocol shape
+            // as the native engine, just routed via the loopback channel
+            // here. On a real network the same VersionVector request goes
+            // out via libp2p request-response.
+            while let Some(req) = pending_out.pop_front() {
+                if end.out_tx.send(req).is_err() {
+                    log::info!("WebSyncClient (loopback): peer dropped while draining outbox");
+                    return;
+                }
+            }
+            send_version_vector(&state, &end.out_tx).await;
+        }
+        was_online = now_online;
+
+        tokio::select! {
+            cmd = cmd_rx.recv() => {
+                match cmd {
+                    Some(Command::Publish(changeset)) => {
+                        let req = build_push_request(&state.topic, state.group_key.as_ref(), changeset);
+                        if link.is_online() {
+                            let _ = end.out_tx.send(req);
+                        } else {
+                            pending_out.push_back(req);
+                        }
+                    }
+                    Some(Command::SubmitLocal { table, pk, columns, ack }) => {
+                        let result = handle_submit_local_loopback(
+                            &state,
+                            &mut end,
+                            &link,
+                            &mut pending_out,
+                            table,
+                            pk,
+                            columns,
+                        )
+                        .await;
+                        let _ = ack.send(result);
+                    }
+                    None => {
+                        log::info!("WebSyncClient (loopback): command channel closed");
+                        return;
+                    }
+                }
+            }
+            incoming = end.in_rx.recv() => {
+                match incoming {
+                    Some(req) => {
+                        if link.is_online() {
+                            handle_loopback_request(req, &state, &end.out_tx).await;
+                        } else {
+                            // Honest to a real network: messages destined
+                            // for an offline peer are dropped on the floor.
+                            // The version-vector catch-up on reconnect
+                            // (above) is what recovers them.
+                            log::debug!("loopback: dropping incoming while offline");
+                        }
+                    }
+                    None => {
+                        log::info!("WebSyncClient (loopback): peer channel closed");
+                        return;
+                    }
+                }
+            }
+            _ = link.notify.notified() => {
+                // Online flag may have flipped — top of loop handles
+                // the catch-up trigger when we come back online. Spurious
+                // notifies cost an extra select tick; harmless.
+            }
+        }
+    }
+}
+
+/// Send a `VersionVector` request over the loopback transport, using the
+/// last `db_version` we recorded from our peer. The peer responds via
+/// [`handle_loopback_request`] with a `Push` containing every shadow
+/// change strictly newer than that.
+async fn send_version_vector(state: &EngineState, out_tx: &mpsc::UnboundedSender<SyncRequest>) {
+    let store = match &state.store {
+        Some(s) => s,
+        None => return, // ephemeral clients don't track peer versions
+    };
+    let last_seen = match store.get_peer_version(LOOPBACK_PEER_KEY).await {
+        Ok(v) => v,
+        Err(e) => {
+            log::warn!("loopback: peer_version read failed: {e}");
+            0
+        }
+    };
+    let my_db_version = *state.db_version.lock().await;
+    let mut req = SyncRequest::VersionVector {
+        my_db_version,
+        your_last_db_version: last_seen,
+        site_id: state.site_id,
+        topic: state.topic.clone(),
+        hmac: None,
+    };
+    if let Some(gk) = &state.group_key {
+        if let Ok(bytes) = serde_json::to_vec(&req) {
+            let tag = gk.mac(&bytes);
+            if let SyncRequest::VersionVector { ref mut hmac, .. } = req {
+                *hmac = Some(tag);
+            }
+        }
+    }
+    log::debug!(
+        "loopback: requesting catch-up since db_version={last_seen} (we are at {my_db_version})"
+    );
+    let _ = out_tx.send(req);
+}
+
+async fn handle_submit_local_loopback(
+    state: &EngineState,
+    end: &mut LoopbackEnd,
+    link: &LoopbackLink,
+    pending_out: &mut VecDeque<SyncRequest>,
+    table: String,
+    pk: String,
+    columns: Vec<(String, serde_json::Value)>,
+) -> Result<u64, WebSyncError> {
+    // Mirrors handle_submit_local — bumps db_version, persists shadow per
+    // column, then ships the changeset. The only difference is the
+    // out-of-engine transport: a channel send instead of swarm.send_request.
+    let mut dv = state.db_version.lock().await;
+    *dv += 1;
+    let new_db_version = *dv;
+    if let Some(store) = &state.store {
+        store
+            .put_db_version(new_db_version)
+            .await
+            .map_err(|e| WebSyncError::Store(e.to_string()))?;
+    }
+    drop(dv);
+
+    let mut changes: Vec<ColumnChange> = Vec::with_capacity(columns.len());
+    for (seq, (cid, val)) in columns.into_iter().enumerate() {
+        let prev = if let Some(store) = &state.store {
+            store
+                .get_shadow(&table, &pk, &cid)
+                .await
+                .map_err(|e| WebSyncError::Store(e.to_string()))?
+        } else {
+            None
+        };
+        let next_col_version = prev.as_ref().map(|r| r.col_version + 1).unwrap_or(1);
+        let next_cl = prev
+            .as_ref()
+            .map(|r| r.cl.max(next_col_version))
+            .unwrap_or(next_col_version);
+
+        if let Some(store) = &state.store {
+            let row = ShadowRow {
+                val: Some(val.clone()),
+                site_id: state.site_id.0,
+                col_version: next_col_version,
+                cl: next_cl,
+                seq: seq as u32,
+                db_version: new_db_version,
+            };
+            store
+                .put_shadow(&table, &pk, &cid, &row)
+                .await
+                .map_err(|e| WebSyncError::Store(e.to_string()))?;
+        }
+
+        changes.push(ColumnChange {
+            table: TableName(table.clone()),
+            pk: PrimaryKey(pk.clone()),
+            cid: ColumnName(cid),
+            val: Some(val),
+            site_id: state.site_id,
+            col_version: next_col_version,
+            cl: next_cl,
+            seq: seq as u32,
+            db_version: new_db_version,
+        });
+    }
+
+    // Echo the local writes on resolved_tx so reactive subscribers
+    // (e.g. `dioxus::use_synced_table`) update their in-memory views
+    // for local edits the same way they do for remote ones. The shadow
+    // is already durably persisted; this is purely a wake-up for
+    // listeners. Lagged subscribers drop messages — fine, they'd
+    // re-materialize from the store on next mount.
+    for ch in &changes {
+        let _ = state.resolved_tx.send(ch.clone());
+    }
+
+    let changeset = SyncChangeset {
+        site_id: state.site_id,
+        db_version: new_db_version,
+        changes,
+    };
+
+    let req = build_push_request(&state.topic, state.group_key.as_ref(), changeset);
+    if link.is_online() {
+        let _ = end.out_tx.send(req);
+    } else {
+        // Offline: shadow + db_version are already durably persisted to
+        // IndexedDB above, so the local write is "real". Buffer the
+        // outbound changeset in pending_out — the run loop drains it
+        // when the link transitions back to online.
+        pending_out.push_back(req);
+    }
+    Ok(new_db_version)
+}
+
+/// Loopback equivalent of [`handle_snapshot_event`] for incoming
+/// `SyncRequest`s.
+///
+/// In loopback there's no separate response channel — the libp2p
+/// `request_response` round-trip is collapsed onto the same one-way
+/// channel by sending catch-up data back as an unsolicited
+/// [`SyncRequest::Push`]. The receiving side can't tell whether a Push
+/// is real-time fan-out or catch-up reply, but it doesn't need to: the
+/// merge logic is identical either way, courtesy of CRDT.
+async fn handle_loopback_request(
+    req: SyncRequest,
+    state: &EngineState,
+    out_tx: &mpsc::UnboundedSender<SyncRequest>,
+) {
+    match req {
+        SyncRequest::Push {
+            changeset,
+            topic,
+            hmac,
+        } => {
+            if topic != state.topic {
+                log::debug!("loopback: dropping Push — topic mismatch");
+                return;
+            }
+            if let Some(gk) = &state.group_key {
+                let verify = SyncRequest::Push {
+                    changeset: changeset.clone(),
+                    topic: topic.clone(),
+                    hmac: None,
+                };
+                let bytes = match serde_json::to_vec(&verify) {
+                    Ok(b) => b,
+                    Err(_) => return,
+                };
+                let tag = match hmac {
+                    Some(t) => t,
+                    None => {
+                        log::debug!("loopback: dropping Push — missing HMAC");
+                        return;
+                    }
+                };
+                if !gk.verify(&bytes, &tag) {
+                    log::debug!("loopback: dropping Push — bad HMAC");
+                    return;
+                }
+            }
+            let _ = state.inbound_tx.send(changeset.clone());
+            apply_remote_changeset_loopback(state, LOOPBACK_PEER_KEY, &changeset).await;
+        }
+        SyncRequest::VersionVector {
+            my_db_version: peer_db_version,
+            your_last_db_version: since,
+            site_id: peer_site,
+            topic,
+            hmac,
+        } => {
+            if topic != state.topic {
+                log::debug!("loopback: dropping VersionVector — topic mismatch");
+                return;
+            }
+            if let Some(gk) = &state.group_key {
+                let verify = SyncRequest::VersionVector {
+                    my_db_version: peer_db_version,
+                    your_last_db_version: since,
+                    site_id: peer_site,
+                    topic: topic.clone(),
+                    hmac: None,
+                };
+                let bytes = match serde_json::to_vec(&verify) {
+                    Ok(b) => b,
+                    Err(_) => return,
+                };
+                let tag = match hmac {
+                    Some(t) => t,
+                    None => {
+                        log::debug!("loopback: dropping VersionVector — missing HMAC");
+                        return;
+                    }
+                };
+                if !gk.verify(&bytes, &tag) {
+                    log::debug!("loopback: dropping VersionVector — bad HMAC");
+                    return;
+                }
+            }
+
+            // Build catch-up changeset from local shadow.
+            let store = match &state.store {
+                Some(s) => s,
+                None => return, // ephemeral clients have nothing to send
+            };
+            let changes = match store.get_changes_since(since).await {
+                Ok(c) => c,
+                Err(e) => {
+                    log::warn!("loopback: catch-up scan failed: {e}");
+                    return;
+                }
+            };
+            log::debug!(
+                "loopback: VersionVector since={since} → returning {} changes",
+                changes.len()
+            );
+            if !changes.is_empty() {
+                let my_db_version = *state.db_version.lock().await;
+                let changeset = SyncChangeset {
+                    site_id: state.site_id,
+                    db_version: my_db_version,
+                    changes,
+                };
+                let push = build_push_request(&state.topic, state.group_key.as_ref(), changeset);
+                let _ = out_tx.send(push);
+            }
+        }
+        SyncRequest::IdentityAnnounce { .. } => {
+            // Identity announce is a presence signal in the native
+            // engine; loopback has no concept of presence beyond the
+            // online flag, so we ignore.
+        }
+    }
+}
+
+/// Conflict-resolve every column change against persisted shadow state.
+/// Same logic as `apply_remote_changeset` but takes a string peer id
+/// (since loopback has no real `libp2p::PeerId`).
+async fn apply_remote_changeset_loopback(
+    state: &EngineState,
+    peer: &str,
+    changeset: &SyncChangeset,
+) {
+    let store = match &state.store {
+        Some(s) => s,
+        None => {
+            for change in &changeset.changes {
+                let _ = state.resolved_tx.send(change.clone());
+            }
+            return;
+        }
+    };
+
+    for change in &changeset.changes {
+        let local = match store
+            .get_shadow(&change.table.0, &change.pk.0, &change.cid.0)
+            .await
+        {
+            Ok(v) => v,
+            Err(e) => {
+                log::warn!("loopback: shadow read failed: {e}");
+                continue;
+            }
+        };
+
+        let remote_val = match &change.val {
+            Some(v) => serde_json::to_vec(v).unwrap_or_default(),
+            None => Vec::new(),
+        };
+        let (local_col_version, local_val_bytes, local_site_id) = match &local {
+            Some(r) => {
+                let bytes = r
+                    .val
+                    .as_ref()
+                    .map(|v| serde_json::to_vec(v).unwrap_or_default())
+                    .unwrap_or_default();
+                (r.col_version, bytes, NodeId(r.site_id))
+            }
+            None => (0, Vec::new(), NodeId([0u8; 16])),
+        };
+
+        let apply = conflict::should_apply_column(
+            change.col_version,
+            &remote_val,
+            &change.site_id,
+            local_col_version,
+            &local_val_bytes,
+            &local_site_id,
+        );
+        if !apply {
+            continue;
+        }
+
+        let new_row = ShadowRow {
+            val: change.val.clone(),
+            site_id: change.site_id.0,
+            col_version: change.col_version,
+            cl: change.cl,
+            seq: change.seq,
+            db_version: change.db_version,
+        };
+        if let Err(e) = store
+            .put_shadow(&change.table.0, &change.pk.0, &change.cid.0, &new_row)
+            .await
+        {
+            log::warn!("loopback: shadow write failed: {e}");
+            continue;
+        }
+
+        let _ = state.resolved_tx.send(change.clone());
+    }
+
+    if let Err(e) = store.set_peer_version(peer, changeset.db_version).await {
+        log::debug!("loopback: peer_version write failed: {e}");
+    }
+}
+
+async fn run_swarm(
+    mut swarm: Swarm<WebBehaviour>,
+    mut cmd_rx: mpsc::UnboundedReceiver<Command>,
+    state: EngineState,
+) {
+    let mut connected: HashSet<LibPeerId> = HashSet::new();
+    // The relay peer-id is *not* inserted into `connected` (it isn't
+    // a sync peer), so we track its link state on the side. The UI
+    // status panel reads this through `WebSyncStatus.relay_connected`.
+    let mut relay_connected = false;
+    // Peers (currently only the relay) we want to send `AnnouncePresence`
+    // to but couldn't synchronously inside the `ConnectionEstablished`
+    // handler — see the comment in `handle_event` for the reentrancy
+    // reason. Drained on every loop iteration before re-polling.
+    let mut pending_announces: Vec<LibPeerId> = Vec::new();
+
+    loop {
+        for peer in pending_announces.drain(..) {
+            log::info!("WebSyncClient: sending deferred AnnouncePresence to {peer}");
+            let req = PushRequest::AnnouncePresence {
+                topic: state.topic.clone(),
+            };
+            let _ = swarm.behaviour_mut().push.send_request(&peer, req);
+        }
+
+        tokio::select! {
+            cmd = cmd_rx.recv() => {
+                match cmd {
+                    Some(Command::Publish(changeset)) => {
+                        let req = build_push_request(&state.topic, state.group_key.as_ref(), changeset);
+                        for peer in connected.iter().copied().collect::<Vec<_>>() {
+                            swarm.behaviour_mut().snapshot.send_request(&peer, req.clone());
+                        }
+                    }
+                    Some(Command::SubmitLocal { table, pk, columns, ack }) => {
+                        let result = handle_submit_local(&state, &mut swarm, &connected, table, pk, columns).await;
+                        let _ = ack.send(result);
+                    }
+                    None => {
+                        log::info!("WebSyncClient: command channel closed, exiting");
+                        return;
+                    }
+                }
+            }
+            event = swarm.select_next_some() => {
+                handle_event(event, &mut connected, &mut relay_connected, &mut pending_announces, &state, &mut swarm).await;
+            }
+        }
+    }
+}
+
+async fn handle_submit_local(
+    state: &EngineState,
+    swarm: &mut Swarm<WebBehaviour>,
+    connected: &HashSet<LibPeerId>,
+    table: String,
+    pk: String,
+    columns: Vec<(String, serde_json::Value)>,
+) -> Result<u64, WebSyncError> {
+    // Bump db_version once for the whole batch — matches native semantics
+    // (every local write is exactly one `db_version` step).
+    let mut dv = state.db_version.lock().await;
+    *dv += 1;
+    let new_db_version = *dv;
+    if let Some(store) = &state.store {
+        store
+            .put_db_version(new_db_version)
+            .await
+            .map_err(|e| WebSyncError::Store(e.to_string()))?;
+    }
+    drop(dv);
+
+    let mut changes: Vec<ColumnChange> = Vec::with_capacity(columns.len());
+    for (seq, (cid, val)) in columns.into_iter().enumerate() {
+        // Look up current shadow → next col_version.
+        let prev = if let Some(store) = &state.store {
+            store
+                .get_shadow(&table, &pk, &cid)
+                .await
+                .map_err(|e| WebSyncError::Store(e.to_string()))?
+        } else {
+            None
+        };
+        let next_col_version = prev.as_ref().map(|r| r.col_version + 1).unwrap_or(1);
+        let next_cl = prev
+            .as_ref()
+            .map(|r| r.cl.max(next_col_version))
+            .unwrap_or(next_col_version);
+
+        if let Some(store) = &state.store {
+            let row = ShadowRow {
+                val: Some(val.clone()),
+                site_id: state.site_id.0,
+                col_version: next_col_version,
+                cl: next_cl,
+                seq: seq as u32,
+                db_version: new_db_version,
+            };
+            store
+                .put_shadow(&table, &pk, &cid, &row)
+                .await
+                .map_err(|e| WebSyncError::Store(e.to_string()))?;
+        }
+
+        changes.push(ColumnChange {
+            table: TableName(table.clone()),
+            pk: PrimaryKey(pk.clone()),
+            cid: ColumnName(cid),
+            val: Some(val),
+            site_id: state.site_id,
+            col_version: next_col_version,
+            cl: next_cl,
+            seq: seq as u32,
+            db_version: new_db_version,
+        });
+    }
+
+    // Echo local writes on resolved_tx so reactive subscribers update
+    // for local edits the same way they do for remote ones. See the
+    // matching block in `handle_submit_local_loopback`.
+    for ch in &changes {
+        let _ = state.resolved_tx.send(ch.clone());
+    }
+
+    let changeset = SyncChangeset {
+        site_id: state.site_id,
+        db_version: new_db_version,
+        changes,
+    };
+
+    let req = build_push_request(&state.topic, state.group_key.as_ref(), changeset);
+    let peers: Vec<LibPeerId> = connected.iter().copied().collect();
+    log::info!(
+        "WebSyncClient: pushing changeset (db_v={new_db_version}) to {} peer(s): {:?}",
+        peers.len(),
+        peers.iter().map(|p| p.to_string()).collect::<Vec<_>>()
+    );
+    for peer in &peers {
+        let id = swarm
+            .behaviour_mut()
+            .snapshot
+            .send_request(peer, req.clone());
+        log::debug!("WebSyncClient: send_request → peer {peer} req_id={id:?}");
+    }
+    Ok(new_db_version)
+}
+
+async fn handle_event(
+    event: SwarmEvent<WebBehaviourEvent>,
+    connected: &mut HashSet<LibPeerId>,
+    relay_connected: &mut bool,
+    pending_announces: &mut Vec<LibPeerId>,
+    state: &EngineState,
+    swarm: &mut Swarm<WebBehaviour>,
+) {
+    match event {
+        SwarmEvent::ConnectionEstablished {
+            peer_id, endpoint, ..
+        } => {
+            if Some(peer_id) == state.relay_peer_id {
+                // Connected to the relay — register our topic and ask
+                // for the current peer list. We deliberately do NOT add
+                // it to `connected`: the relay isn't a sync peer and
+                // shouldn't see snapshot Push fan-out.
+                //
+                // Defer the actual `send_request` to the next select
+                // iteration. Calling it synchronously here triggers a
+                // wasm_bindgen_futures executor reentrancy panic
+                // ("RefCell already borrowed" in singlethread.rs:142):
+                // the request_response substream open path can wake a
+                // task whose poll re-enters `Inner::run` while we still
+                // hold the outer borrow from `swarm.select_next_some()`.
+                log::info!("WebSyncClient: connected to relay {peer_id}, queuing announce");
+                log::debug!(
+                    "WebSyncClient: relay connection endpoint = {} ({})",
+                    if endpoint.is_dialer() {
+                        "dialer"
+                    } else {
+                        "listener"
+                    },
+                    endpoint.get_remote_address()
+                );
+                *relay_connected = true;
+                pending_announces.push(peer_id);
+            } else {
+                connected.insert(peer_id);
+                log::info!(
+                    "WebSyncClient: connected to peer {peer_id} (connected count={})",
+                    connected.len()
+                );
+                log::debug!(
+                    "WebSyncClient: peer connection endpoint = {} ({})",
+                    if endpoint.is_dialer() {
+                        "dialer"
+                    } else {
+                        "listener"
+                    },
+                    endpoint.get_remote_address()
+                );
+            }
+            push_status(state, connected, *relay_connected);
+        }
+        SwarmEvent::ConnectionClosed { peer_id, cause, .. } => {
+            if Some(peer_id) == state.relay_peer_id {
+                log::info!("WebSyncClient: disconnected from relay {peer_id} (cause={cause:?})");
+                *relay_connected = false;
+            } else {
+                connected.remove(&peer_id);
+                log::info!(
+                    "WebSyncClient: disconnected from peer {peer_id} (connected count={}, cause={cause:?})",
+                    connected.len()
+                );
+            }
+            push_status(state, connected, *relay_connected);
+        }
+        SwarmEvent::OutgoingConnectionError { error, peer_id, .. } => {
+            log::warn!("WebSyncClient: dial failure ({peer_id:?}): {error}");
+        }
+        SwarmEvent::Behaviour(WebBehaviourEvent::Snapshot(ev)) => {
+            handle_snapshot_event(ev, state, swarm).await;
+        }
+        SwarmEvent::Behaviour(WebBehaviourEvent::Push(ev)) => {
+            handle_push_event(ev, state, swarm);
+        }
+        SwarmEvent::Behaviour(WebBehaviourEvent::Ping(_)) => {}
+        SwarmEvent::Behaviour(WebBehaviourEvent::Identify(_)) => {}
+        SwarmEvent::Behaviour(WebBehaviourEvent::RelayClient(_)) => {}
+        _ => {}
+    }
+}
+
+/// Handle inbound and outbound `push` request_response events.
+///
+/// Two cases that matter:
+/// - **`Response`** to our own outbound `AnnouncePresence`: a
+///   `PushResponse::PeerList` carrying multiaddrs. We dial each one;
+///   they're already fully-qualified circuit-relay multiaddrs (the
+///   relay's `build_peer_addrs` adds `/p2p/<relay>/p2p-circuit/p2p/<peer>`
+///   suffix).
+/// - **`Request`** of `PushRequest::PeerJoined`: the relay telling us
+///   a new peer joined our topic. **Critical security check**: we
+///   only accept this from `state.relay_peer_id` — otherwise any
+///   connected peer could trick us into dialing arbitrary addresses.
+fn handle_push_event(
+    event: request_response::Event<PushRequest, PushResponse>,
+    state: &EngineState,
+    swarm: &mut Swarm<WebBehaviour>,
+) {
+    use request_response::{Event, Message};
+    match event {
+        Event::Message {
+            peer,
+            message: Message::Request {
+                request, channel, ..
+            },
+            ..
+        } => match request {
+            PushRequest::PeerJoined { topic, peer_addrs } => {
+                if Some(peer) != state.relay_peer_id {
+                    log::debug!("WebSyncClient: dropping PeerJoined from non-relay peer {peer}");
+                    let _ = swarm.behaviour_mut().push.send_response(
+                        channel,
+                        PushResponse::Error {
+                            message: "not authorized".into(),
+                        },
+                    );
+                    return;
+                }
+                if topic != state.topic {
+                    log::debug!(
+                        "WebSyncClient: dropping PeerJoined — topic mismatch ({topic} vs {})",
+                        state.topic
+                    );
+                    let _ = swarm
+                        .behaviour_mut()
+                        .push
+                        .send_response(channel, PushResponse::Ok);
+                    return;
+                }
+                log::info!(
+                    "WebSyncClient: relay introduced new peer with {} addrs",
+                    peer_addrs.len()
+                );
+                for addr_str in peer_addrs {
+                    match addr_str.parse::<Multiaddr>() {
+                        Ok(addr) => {
+                            if let Err(e) = swarm.dial(addr.clone()) {
+                                log::debug!(
+                                    "WebSyncClient: dial of introduced peer {addr} failed: {e}"
+                                );
+                            }
+                        }
+                        Err(e) => log::debug!(
+                            "WebSyncClient: invalid PeerJoined multiaddr {addr_str:?}: {e}"
+                        ),
+                    }
+                }
+                let _ = swarm
+                    .behaviour_mut()
+                    .push
+                    .send_response(channel, PushResponse::Ok);
+            }
+            // Other PushRequest variants (RegisterToken, NotifyTopic,
+            // etc.) are FCM-side concerns the browser doesn't speak.
+            // Acknowledge generically.
+            _ => {
+                let _ = swarm
+                    .behaviour_mut()
+                    .push
+                    .send_response(channel, PushResponse::Ok);
+            }
+        },
+        Event::Message {
+            peer,
+            message: Message::Response { response, .. },
+            ..
+        } => match response {
+            PushResponse::PeerList { peers } => {
+                log::info!(
+                    "WebSyncClient: relay {peer} returned {} known peers",
+                    peers.len()
+                );
+                // Pick exactly ONE multiaddr per destination peer so we
+                // don't kick off multiple parallel dials that libp2p
+                // then immediately tears down via
+                // `max_established_per_peer = 1`. Without this the
+                // engine churns through connect→close→reconnect cycles
+                // on every PeerList round-trip — the user-visible
+                // symptom is that Add fires (`pushing changeset to N
+                // peer(s)`) racing the only stable connection, and
+                // most writes land on the floor.
+                //
+                // Preference order, highest first:
+                //   1. /ws|/wss/.../p2p-circuit/...  — works directly:
+                //      same outer transport as our existing relay
+                //      connection, so the relay-client multiplexes the
+                //      circuit substream onto the live WS conn.
+                //   2. /tcp|/udp/.../p2p-circuit/... — also works
+                //      because relay-client can reuse the existing
+                //      relay conn regardless of the outer's transport
+                //      hint, but kept second since it's slightly less
+                //      direct and we want to bias toward the address
+                //      that matches our actual transport stack.
+                //   3. /ws|/wss/...                   — direct WS to
+                //      another browser peer (rare, but valid).
+                //   4. anything else                  — direct QUIC,
+                //      TCP, etc. The browser has none of these so the
+                //      dial fails fast; only useful as a last-resort
+                //      placeholder so the dedup map has *something* to
+                //      remember the peer-id we already considered.
+                fn score_addr(addr: &Multiaddr) -> u8 {
+                    use libp2p::multiaddr::Protocol;
+                    let mut has_ws = false;
+                    let mut has_circuit = false;
+                    for p in addr.iter() {
+                        match p {
+                            Protocol::Ws(_) | Protocol::Wss(_) => has_ws = true,
+                            Protocol::P2pCircuit => has_circuit = true,
+                            _ => {}
+                        }
+                    }
+                    match (has_ws, has_circuit) {
+                        (true, true) => 4,
+                        (false, true) => 3,
+                        (true, false) => 2,
+                        (false, false) => 1,
+                    }
+                }
+
+                let mut best_per_peer: std::collections::HashMap<LibPeerId, Multiaddr> =
+                    std::collections::HashMap::new();
+                for addr_str in peers {
+                    let addr: Multiaddr = match addr_str.parse() {
+                        Ok(a) => a,
+                        Err(e) => {
+                            log::debug!(
+                                "WebSyncClient: invalid PeerList multiaddr {addr_str:?}: {e}"
+                            );
+                            continue;
+                        }
+                    };
+                    let target_peer = match peer_id_from_multiaddr(&addr) {
+                        Some(p) => p,
+                        None => continue,
+                    };
+                    if target_peer == *swarm.local_peer_id()
+                        || Some(target_peer) == state.relay_peer_id
+                    {
+                        continue;
+                    }
+                    let new_score = score_addr(&addr);
+                    best_per_peer
+                        .entry(target_peer)
+                        .and_modify(|cur| {
+                            if score_addr(cur) < new_score {
+                                *cur = addr.clone();
+                            }
+                        })
+                        .or_insert(addr);
+                }
+
+                for (target, addr) in &best_per_peer {
+                    log::debug!("WebSyncClient: dial(PeerList) → {addr} (peer {target})");
+                    if let Err(e) = swarm.dial(addr.clone()) {
+                        log::warn!(
+                            "WebSyncClient: dial(PeerList) of {addr} returned Err synchronously: {e}"
+                        );
+                    }
+                }
+            }
+            PushResponse::Error { message } => {
+                log::warn!("WebSyncClient: push error from {peer}: {message}");
+            }
+            PushResponse::Ok => {}
+        },
+        Event::OutboundFailure { peer, error, .. } => {
+            log::warn!("WebSyncClient: push outbound to {peer} failed: {error}");
+        }
+        Event::InboundFailure { peer, error, .. } => {
+            log::warn!("WebSyncClient: push inbound from {peer} failed: {error}");
+        }
+        Event::ResponseSent { .. } => {}
+    }
+}
+
+/// Extract the destination peer-id from a multiaddr.
+///
+/// We always want the **last** `/p2p/<id>` component, never the first.
+/// For a direct multiaddr (`/ip4/.../tcp/.../p2p/<peer>`) there's only
+/// one and it's the destination either way. For a circuit-relay
+/// multiaddr (`/ip4/.../tcp/.../p2p/<relay>/p2p-circuit/p2p/<peer>`)
+/// the FIRST `/p2p/` is the relay and the LAST is the actual target —
+/// returning the first means treating every circuit address as if its
+/// destination were the relay, which makes our "skip relay" filter
+/// drop every circuit dial we get from the relay's PeerList. That
+/// turned web→peer push into a no-op (db_v bumps fan out to 0
+/// peers): the relay returned 9 addresses, the only ones that survived
+/// the filter were the 3 direct QUIC ones, the browser has no QUIC
+/// transport, all three failed with "Multiaddr is not supported", and
+/// the engine never opened a connection to the destination peer.
+fn peer_id_from_multiaddr(addr: &Multiaddr) -> Option<LibPeerId> {
+    // `Multiaddr::iter()` is forward-only, so we walk it once and keep
+    // the last `/p2p/<id>` we see.
+    let mut last = None;
+    for p in addr.iter() {
+        if let libp2p::multiaddr::Protocol::P2p(id) = p {
+            last = Some(id);
+        }
+    }
+    last
+}
+
+async fn handle_snapshot_event(
+    event: request_response::Event<SyncRequest, SyncResponse>,
+    state: &EngineState,
+    swarm: &mut Swarm<WebBehaviour>,
+) {
+    use request_response::{Event, Message};
+    match event {
+        Event::Message {
+            peer,
+            message: Message::Request {
+                request, channel, ..
+            },
+            ..
+        } => match request {
+            SyncRequest::Push {
+                changeset,
+                topic,
+                hmac,
+            } => {
+                if topic != state.topic {
+                    log::debug!("WebSyncClient: dropping Push from {peer} — topic mismatch");
+                    return;
+                }
+                if let Some(gk) = &state.group_key {
+                    let verify = SyncRequest::Push {
+                        changeset: changeset.clone(),
+                        topic: topic.clone(),
+                        hmac: None,
+                    };
+                    let bytes = match serde_json::to_vec(&verify) {
+                        Ok(b) => b,
+                        Err(_) => return,
+                    };
+                    let tag = match hmac {
+                        Some(t) => t,
+                        None => {
+                            log::debug!("WebSyncClient: dropping Push from {peer} — missing HMAC");
+                            return;
+                        }
+                    };
+                    if !gk.verify(&bytes, &tag) {
+                        log::debug!("WebSyncClient: dropping Push from {peer} — bad HMAC");
+                        return;
+                    }
+                }
+
+                let _ = state.inbound_tx.send(changeset.clone());
+                apply_remote_changeset(state, &peer, &changeset).await;
+
+                let _ = swarm
+                    .behaviour_mut()
+                    .snapshot
+                    .send_response(channel, SyncResponse::PushAck);
+            }
+            // Real-network VersionVector handler. Verify HMAC + topic,
+            // scan persisted shadow for changes the peer hasn't seen,
+            // and respond with a `ChangesetResponse`. Mirrors the
+            // loopback handler's logic — same store, same query — just
+            // routed through libp2p's request_response instead of
+            // re-using the Push channel.
+            SyncRequest::VersionVector {
+                my_db_version: peer_db_version,
+                your_last_db_version: since,
+                site_id: peer_site,
+                topic: req_topic,
+                hmac,
+            } => {
+                if req_topic != state.topic {
+                    log::debug!(
+                        "WebSyncClient: dropping VersionVector from {peer} — topic mismatch"
+                    );
+                    return;
+                }
+                if let Some(gk) = &state.group_key {
+                    let verify = SyncRequest::VersionVector {
+                        my_db_version: peer_db_version,
+                        your_last_db_version: since,
+                        site_id: peer_site,
+                        topic: req_topic.clone(),
+                        hmac: None,
+                    };
+                    let bytes = match serde_json::to_vec(&verify) {
+                        Ok(b) => b,
+                        Err(_) => return,
+                    };
+                    let tag = match hmac {
+                        Some(t) => t,
+                        None => {
+                            log::debug!(
+                                "WebSyncClient: dropping VersionVector from {peer} — missing HMAC"
+                            );
+                            return;
+                        }
+                    };
+                    if !gk.verify(&bytes, &tag) {
+                        log::debug!("WebSyncClient: dropping VersionVector from {peer} — bad HMAC");
+                        return;
+                    }
+                }
+
+                let changes: Vec<ColumnChange> = match &state.store {
+                    Some(store) => match store.get_changes_since(since).await {
+                        Ok(c) => c,
+                        Err(e) => {
+                            log::warn!("WebSyncClient: catch-up scan failed: {e}");
+                            Vec::new()
+                        }
+                    },
+                    None => Vec::new(),
+                };
+                let my_db_version = *state.db_version.lock().await;
+                let mut resp = SyncResponse::ChangesetResponse {
+                    changes,
+                    my_db_version,
+                    your_last_db_version: peer_db_version,
+                    site_id: state.site_id,
+                    topic: state.topic.clone(),
+                    hmac: None,
+                };
+                if let Some(gk) = &state.group_key {
+                    let unsigned = match &resp {
+                        SyncResponse::ChangesetResponse {
+                            changes,
+                            my_db_version,
+                            your_last_db_version,
+                            site_id,
+                            topic,
+                            ..
+                        } => SyncResponse::ChangesetResponse {
+                            changes: changes.clone(),
+                            my_db_version: *my_db_version,
+                            your_last_db_version: *your_last_db_version,
+                            site_id: *site_id,
+                            topic: topic.clone(),
+                            hmac: None,
+                        },
+                        _ => resp.clone(),
+                    };
+                    if let Ok(bytes) = serde_json::to_vec(&unsigned) {
+                        let tag = gk.mac(&bytes);
+                        if let SyncResponse::ChangesetResponse { ref mut hmac, .. } = resp {
+                            *hmac = Some(tag);
+                        }
+                    }
+                }
+                let _ = swarm.behaviour_mut().snapshot.send_response(channel, resp);
+            }
+            SyncRequest::IdentityAnnounce { .. } => {
+                let _ = swarm
+                    .behaviour_mut()
+                    .snapshot
+                    .send_response(channel, SyncResponse::IdentityAck);
+            }
+        },
+        Event::Message {
+            message: Message::Response { .. },
+            ..
+        } => {
+            // PushAck etc. — no-op for now.
+        }
+        Event::OutboundFailure { peer, error, .. } => {
+            log::warn!("WebSyncClient: outbound to {peer} failed: {error}");
+        }
+        Event::InboundFailure { peer, error, .. } => {
+            log::warn!("WebSyncClient: inbound from {peer} failed: {error}");
+        }
+        Event::ResponseSent { .. } => {}
+    }
+}
+
+/// Conflict-resolve every column change against persisted shadow state.
+/// Winners are persisted and emitted on `resolved_tx`. Losers are dropped.
+///
+/// Mirrors the native engine's `apply_remote_changeset` minus the table
+/// data side — browser apps own that and apply via `subscribe_resolved`.
+/// On ephemeral clients (no store), every change is treated as a winner
+/// and emitted unchanged, since there is no local state to compare.
+async fn apply_remote_changeset(state: &EngineState, peer: &LibPeerId, changeset: &SyncChangeset) {
+    let store = match &state.store {
+        Some(s) => s,
+        None => {
+            // Ephemeral: surface every change as resolved.
+            for change in &changeset.changes {
+                let _ = state.resolved_tx.send(change.clone());
+            }
+            return;
+        }
+    };
+
+    for change in &changeset.changes {
+        let local = match store
+            .get_shadow(&change.table.0, &change.pk.0, &change.cid.0)
+            .await
+        {
+            Ok(v) => v,
+            Err(e) => {
+                log::warn!("WebSyncClient: shadow read failed: {e}");
+                continue;
+            }
+        };
+
+        let remote_val = match &change.val {
+            Some(v) => serde_json::to_vec(v).unwrap_or_default(),
+            None => Vec::new(),
+        };
+        let (local_col_version, local_val_bytes, local_site_id) = match &local {
+            Some(r) => {
+                let bytes = r
+                    .val
+                    .as_ref()
+                    .map(|v| serde_json::to_vec(v).unwrap_or_default())
+                    .unwrap_or_default();
+                (r.col_version, bytes, NodeId(r.site_id))
+            }
+            None => (0, Vec::new(), NodeId([0u8; 16])),
+        };
+
+        let apply = conflict::should_apply_column(
+            change.col_version,
+            &remote_val,
+            &change.site_id,
+            local_col_version,
+            &local_val_bytes,
+            &local_site_id,
+        );
+        if !apply {
+            continue;
+        }
+
+        let new_row = ShadowRow {
+            val: change.val.clone(),
+            site_id: change.site_id.0,
+            col_version: change.col_version,
+            cl: change.cl,
+            seq: change.seq,
+            db_version: change.db_version,
+        };
+        if let Err(e) = store
+            .put_shadow(&change.table.0, &change.pk.0, &change.cid.0, &new_row)
+            .await
+        {
+            log::warn!("WebSyncClient: shadow write failed: {e}");
+            continue;
+        }
+
+        let _ = state.resolved_tx.send(change.clone());
+    }
+
+    // Track the highest db_version seen from this peer for a future
+    // version-vector catch-up. Failure here is non-fatal — it just means
+    // catch-up will start from an earlier point next time.
+    if let Err(e) = store
+        .set_peer_version(&peer.to_string(), changeset.db_version)
+        .await
+    {
+        log::debug!("WebSyncClient: peer_version write failed: {e}");
+    }
+}
+
+fn build_push_request(
+    topic: &str,
+    group_key: Option<&GroupKey>,
+    changeset: SyncChangeset,
+) -> SyncRequest {
+    let mut req = SyncRequest::Push {
+        changeset,
+        topic: topic.to_string(),
+        hmac: None,
+    };
+    if let Some(gk) = group_key {
+        // Serialize with hmac=None, MAC the canonical bytes, then attach.
+        // Mirrors the native engine — keeps the verification path identical.
+        if let Ok(bytes) = serde_json::to_vec(&req) {
+            let tag = gk.mac(&bytes);
+            if let SyncRequest::Push { ref mut hmac, .. } = req {
+                *hmac = Some(tag);
+            }
+        }
+    }
+    req
+}
+
+/// Generate 16 cryptographically random bytes for a fresh `site_id`.
+///
+/// The browser provides this via `crypto.getRandomValues`; getrandom 0.2
+/// (with the `js` feature) and 0.3 (with `wasm_js` feature + cfg) both
+/// route to it.
+fn rand_site_id() -> [u8; 16] {
+    let mut buf = [0u8; 16];
+    getrandom::getrandom(&mut buf).expect("crypto.getRandomValues failed");
+    buf
+}

--- a/wavesyncdb/src/web_entity.rs
+++ b/wavesyncdb/src/web_entity.rs
@@ -1,0 +1,72 @@
+//! Browser-side mapping between a Rust struct and the engine's
+//! column-bag representation.
+//!
+//! On native, the [`SyncEntity`](crate::SyncEntity) derive macro lives
+//! on top of SeaORM and tells the engine how to serialize / deserialize
+//! a row. The browser path has no SeaORM, so this trait is the explicit
+//! contract apps implement to plug their domain types into
+//! [`use_synced_table`](crate::dioxus::use_synced_table) and
+//! [`WebSyncClient::submit`](crate::WebSyncClient::submit).
+//!
+//! Implementing it is mechanical — extract each field from the column
+//! map in `from_columns`, dump each field back into a `(name, value)`
+//! list in `to_columns`, return your primary-key field as a string in
+//! `pk`. There's no derive macro yet; with patterns on a few apps it
+//! could be added.
+//!
+//! ## Example
+//!
+//! ```ignore
+//! use std::collections::HashMap;
+//! use serde_json::Value;
+//! use wavesyncdb::BrowserEntity;
+//!
+//! #[derive(Clone, Debug)]
+//! struct Task { id: String, title: String, done: bool }
+//!
+//! impl BrowserEntity for Task {
+//!     fn from_columns(pk: &str, cols: &HashMap<String, Value>) -> Self {
+//!         Task {
+//!             id: pk.to_string(),
+//!             title: cols.get("title").and_then(|v| v.as_str()).unwrap_or("").to_string(),
+//!             done: cols.get("done").and_then(|v| v.as_bool()).unwrap_or(false),
+//!         }
+//!     }
+//!     fn to_columns(&self) -> Vec<(String, Value)> {
+//!         vec![
+//!             ("title".into(), Value::String(self.title.clone())),
+//!             ("done".into(), Value::Bool(self.done)),
+//!         ]
+//!     }
+//!     fn pk(&self) -> String { self.id.clone() }
+//! }
+//! ```
+
+use std::collections::HashMap;
+
+use serde_json::Value;
+
+/// Bidirectional mapping between an app entity and the engine's
+/// column-bag wire shape.
+///
+/// `'static` is required because Dioxus signals carry the type around
+/// across spawned futures; `Clone` is required because materialized
+/// entities are cloned out of the signal for rendering.
+pub trait BrowserEntity: Clone + 'static {
+    /// Build an instance from the persisted column map.
+    ///
+    /// `pk` is passed separately because the engine stores primary keys
+    /// outside the column bag (in the shadow row's key). Implementations
+    /// usually copy `pk` into the entity's id field and pull the rest
+    /// from `cols`.
+    fn from_columns(pk: &str, cols: &HashMap<String, Value>) -> Self;
+
+    /// Serialize the entity into the column-bag shape `submit_local_write`
+    /// expects. The primary key is **not** included here — the caller
+    /// passes [`Self::pk`] separately.
+    fn to_columns(&self) -> Vec<(String, Value)>;
+
+    /// Return the primary-key value as a string. Used as the shadow
+    /// table key and to identify the row across peers.
+    fn pk(&self) -> String;
+}

--- a/wavesyncdb/src/web_store.rs
+++ b/wavesyncdb/src/web_store.rs
@@ -1,0 +1,452 @@
+//! Browser-side persistent storage for `web_engine`.
+//!
+//! Backed by IndexedDB via the `idb` crate. Three object stores:
+//!
+//! - **`meta`** — singletons keyed by string: `"site_id"` (16-byte array
+//!   serialized as JSON), `"db_version"` (u64), `"keypair"` (libp2p
+//!   protobuf-encoded keypair bytes). Restoring the keypair on connect is
+//!   what gives a reloaded tab the same `PeerId` it had before — without
+//!   it, the network treats every reload as a brand-new peer.
+//! - **`shadow`** — per-column Lamport state, keyed by
+//!   `"<table>|<pk>|<cid>"`. Mirrors the native `_wavesync_<table>_clocks`
+//!   tables: `(val, site_id, col_version, cl, seq, db_version)`. This is
+//!   what lets conflict resolution work across reloads — without it,
+//!   every restart forgets what version it last saw and remote changes
+//!   that should have lost would re-apply on top of newer local data.
+//! - **`peer_versions`** — per-peer `last_db_version` (u64), keyed by
+//!   peer-id string. Reserved for a future version-vector catch-up; not
+//!   read on this branch but written on every successful incoming Push so
+//!   the data is ready when catch-up lands.
+//!
+//! Key encoding choices follow the same conventions as the native shadow
+//! tables: composite keys are joined with `'|'` (table/pk/cid components
+//! that contain `'|'` would collide, but native uses the same separator
+//! and has not had problems in practice — see `shadow.rs`).
+
+use std::sync::Arc;
+
+use idb::{
+    Database, DatabaseEvent, Error as IdbError, Factory, KeyRange, ObjectStoreParams, Query,
+    TransactionMode,
+};
+use serde::{Deserialize, Serialize};
+use wasm_bindgen::JsValue;
+
+use crate::messages::NodeId;
+
+const STORE_META: &str = "meta";
+const STORE_SHADOW: &str = "shadow";
+const STORE_PEER_VERSIONS: &str = "peer_versions";
+
+const META_SITE_ID: &str = "site_id";
+const META_DB_VERSION: &str = "db_version";
+const META_KEYPAIR: &str = "keypair";
+
+#[derive(Debug, thiserror::Error)]
+pub enum StoreError {
+    #[error("indexeddb error: {0}")]
+    Idb(String),
+    #[error("serde error: {0}")]
+    Serde(String),
+}
+
+impl From<IdbError> for StoreError {
+    fn from(e: IdbError) -> Self {
+        Self::Idb(e.to_string())
+    }
+}
+
+/// One materialized application row — pk plus the latest persisted value
+/// for every column. Returned by [`BrowserStore::list_table_rows`].
+#[derive(Debug, Clone)]
+pub struct ResolvedRow {
+    pub pk: String,
+    pub columns: std::collections::HashMap<String, serde_json::Value>,
+}
+
+/// One persisted shadow-table row — the per-(table, pk, cid) Lamport state.
+///
+/// The shape mirrors `shadow::ShadowRow` on native, except `val` is JSON
+/// (browser doesn't have SQLite blob types) and field types use plain
+/// integers for IndexedDB-friendly serialization.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ShadowRow {
+    pub val: Option<serde_json::Value>,
+    pub site_id: [u8; 16],
+    pub col_version: u64,
+    pub cl: u64,
+    pub seq: u32,
+    pub db_version: u64,
+}
+
+/// Async-friendly handle to the IndexedDB-backed store.
+///
+/// Cheap to clone — internally an `Arc<Database>`. `Database` itself is
+/// `!Send + !Sync`, but the whole web engine runs on the single-threaded
+/// browser event loop via `wasm_bindgen_futures::spawn_local`, so there's
+/// no real cross-thread sharing happening.
+#[derive(Clone)]
+pub struct BrowserStore {
+    db: Arc<Database>,
+}
+
+impl BrowserStore {
+    /// Open or create the IndexedDB database for `store_name`.
+    ///
+    /// The database is named `wavesync-<store_name>`. If the database does
+    /// not exist or its version is older than the current schema, the
+    /// missing object stores are created in `on_upgrade_needed`.
+    pub async fn open(store_name: &str) -> Result<Self, StoreError> {
+        let db_name = format!("wavesync-{store_name}");
+        let factory = Factory::new()?;
+        let mut request = factory.open(&db_name, Some(1))?;
+
+        request.on_upgrade_needed(|event| {
+            let database = event.database().expect("database");
+            let existing = database.store_names();
+            for name in [STORE_META, STORE_SHADOW, STORE_PEER_VERSIONS] {
+                if !existing.contains(&name.to_string()) {
+                    let params = ObjectStoreParams::new();
+                    database
+                        .create_object_store(name, params)
+                        .expect("create object store");
+                }
+            }
+        });
+
+        let db = request.await?;
+        Ok(Self { db: Arc::new(db) })
+    }
+
+    // ── meta singletons ──────────────────────────────────────────────────
+
+    /// Read the persisted libp2p keypair bytes (protobuf-encoded), if any.
+    pub async fn get_keypair(&self) -> Result<Option<Vec<u8>>, StoreError> {
+        self.meta_get_bytes(META_KEYPAIR).await
+    }
+
+    /// Persist a libp2p keypair as protobuf-encoded bytes.
+    ///
+    /// Called once when a fresh client generates a new identity.
+    /// Subsequent `connect_persistent` calls on the same store name will
+    /// restore that identity and present the same `PeerId` to the network.
+    pub async fn put_keypair(&self, bytes: &[u8]) -> Result<(), StoreError> {
+        self.meta_put_bytes(META_KEYPAIR, bytes).await
+    }
+
+    /// Read the persisted local `site_id` (used for CRDT conflict tiebreaks).
+    pub async fn get_site_id(&self) -> Result<Option<NodeId>, StoreError> {
+        let bytes = self.meta_get_bytes(META_SITE_ID).await?;
+        Ok(bytes.and_then(|b| {
+            if b.len() == 16 {
+                let mut a = [0u8; 16];
+                a.copy_from_slice(&b);
+                Some(NodeId(a))
+            } else {
+                None
+            }
+        }))
+    }
+
+    pub async fn put_site_id(&self, id: &NodeId) -> Result<(), StoreError> {
+        self.meta_put_bytes(META_SITE_ID, &id.0).await
+    }
+
+    pub async fn get_db_version(&self) -> Result<u64, StoreError> {
+        let bytes = self.meta_get_bytes(META_DB_VERSION).await?;
+        Ok(bytes
+            .map(|b| {
+                let mut buf = [0u8; 8];
+                buf[..b.len().min(8)].copy_from_slice(&b[..b.len().min(8)]);
+                u64::from_le_bytes(buf)
+            })
+            .unwrap_or(0))
+    }
+
+    pub async fn put_db_version(&self, v: u64) -> Result<(), StoreError> {
+        self.meta_put_bytes(META_DB_VERSION, &v.to_le_bytes()).await
+    }
+
+    async fn meta_get_bytes(&self, key: &str) -> Result<Option<Vec<u8>>, StoreError> {
+        let tx = self
+            .db
+            .transaction(&[STORE_META], TransactionMode::ReadOnly)?;
+        let store = tx.object_store(STORE_META)?;
+        let result = store.get(JsValue::from_str(key))?.await?;
+        tx.commit()?.await?;
+        match result {
+            Some(v) if !v.is_null() && !v.is_undefined() => {
+                let arr: Vec<u8> = serde_wasm_bindgen::from_value(v)
+                    .map_err(|e| StoreError::Serde(e.to_string()))?;
+                Ok(Some(arr))
+            }
+            _ => Ok(None),
+        }
+    }
+
+    async fn meta_put_bytes(&self, key: &str, value: &[u8]) -> Result<(), StoreError> {
+        let tx = self
+            .db
+            .transaction(&[STORE_META], TransactionMode::ReadWrite)?;
+        let store = tx.object_store(STORE_META)?;
+        let js_val =
+            serde_wasm_bindgen::to_value(value).map_err(|e| StoreError::Serde(e.to_string()))?;
+        store.put(&js_val, Some(&JsValue::from_str(key)))?.await?;
+        tx.commit()?.await?;
+        Ok(())
+    }
+
+    // ── shadow rows ──────────────────────────────────────────────────────
+
+    /// Look up the current shadow entry for `(table, pk, cid)`.
+    ///
+    /// `None` means no entry yet — first remote write wins by definition.
+    pub async fn get_shadow(
+        &self,
+        table: &str,
+        pk: &str,
+        cid: &str,
+    ) -> Result<Option<ShadowRow>, StoreError> {
+        let tx = self
+            .db
+            .transaction(&[STORE_SHADOW], TransactionMode::ReadOnly)?;
+        let store = tx.object_store(STORE_SHADOW)?;
+        let key = shadow_key(table, pk, cid);
+        let result = store.get(JsValue::from_str(&key))?.await?;
+        tx.commit()?.await?;
+        match result {
+            Some(v) if !v.is_null() && !v.is_undefined() => {
+                let row: ShadowRow = serde_wasm_bindgen::from_value(v)
+                    .map_err(|e| StoreError::Serde(e.to_string()))?;
+                Ok(Some(row))
+            }
+            _ => Ok(None),
+        }
+    }
+
+    /// Upsert the shadow entry for `(table, pk, cid)`.
+    ///
+    /// Mirrors native's `INSERT OR REPLACE` semantics — IndexedDB's `put`
+    /// is upsert-by-default when a key is supplied.
+    pub async fn put_shadow(
+        &self,
+        table: &str,
+        pk: &str,
+        cid: &str,
+        row: &ShadowRow,
+    ) -> Result<(), StoreError> {
+        let tx = self
+            .db
+            .transaction(&[STORE_SHADOW], TransactionMode::ReadWrite)?;
+        let store = tx.object_store(STORE_SHADOW)?;
+        let key = shadow_key(table, pk, cid);
+        let js_val =
+            serde_wasm_bindgen::to_value(row).map_err(|e| StoreError::Serde(e.to_string()))?;
+        store.put(&js_val, Some(&JsValue::from_str(&key)))?.await?;
+        tx.commit()?.await?;
+        Ok(())
+    }
+
+    // ── shadow scans ─────────────────────────────────────────────────────
+
+    /// Materialize all rows in `table` from the shadow store.
+    ///
+    /// Scans every shadow entry whose key starts with `"<table>|"`, groups
+    /// them by primary key, and returns one [`ResolvedRow`] per pk with
+    /// each column's most recently persisted value. Rows that have a
+    /// `__deleted` shadow entry are excluded.
+    ///
+    /// This is what lets a UI on first mount say "show me everything in
+    /// `tasks`" without the application keeping its own table store —
+    /// the shadow table *is* the materialized state, since per-(pk, cid)
+    /// upsert-in-place gives one entry per column.
+    ///
+    /// Cost is O(rows × cols) — fine for tens of thousands of entries,
+    /// reconsider if shadow size grows beyond that.
+    pub async fn list_table_rows(&self, table: &str) -> Result<Vec<ResolvedRow>, StoreError> {
+        let tx = self
+            .db
+            .transaction(&[STORE_SHADOW], TransactionMode::ReadOnly)?;
+        let store = tx.object_store(STORE_SHADOW)?;
+
+        // Range "<table>|" .. "<table>|\u{ffff}" — `\u{ffff}` is the
+        // largest BMP codepoint, so this catches every key prefixed by
+        // `"<table>|"` regardless of the pk/cid contents. Open ranges
+        // would need exclusive-end handling, so use closed bounds and a
+        // sentinel.
+        let lower = JsValue::from_str(&format!("{table}|"));
+        let upper = JsValue::from_str(&format!("{table}|\u{ffff}"));
+        let range = KeyRange::bound(&lower, &upper, None, None)?;
+        let q = Query::from(range);
+
+        let keys: Vec<JsValue> = store.get_all_keys(Some(q.clone()), None)?.await?;
+        let values: Vec<JsValue> = store.get_all(Some(q), None)?.await?;
+        tx.commit()?.await?;
+
+        if keys.len() != values.len() {
+            return Err(StoreError::Idb(format!(
+                "shadow scan returned {} keys but {} values",
+                keys.len(),
+                values.len()
+            )));
+        }
+
+        // Group by pk → column map. The key format is `<table>|<pk>|<cid>`.
+        let mut rows: std::collections::BTreeMap<String, ResolvedRow> = Default::default();
+        let mut tombstoned: std::collections::HashSet<String> = Default::default();
+        for (k_js, v_js) in keys.into_iter().zip(values.into_iter()) {
+            let key = match k_js.as_string() {
+                Some(s) => s,
+                None => continue,
+            };
+            let parts: Vec<&str> = key.splitn(3, '|').collect();
+            if parts.len() != 3 {
+                continue;
+            }
+            let pk = parts[1].to_string();
+            let cid = parts[2].to_string();
+
+            let row: ShadowRow = serde_wasm_bindgen::from_value(v_js)
+                .map_err(|e| StoreError::Serde(e.to_string()))?;
+
+            if cid == "__deleted" {
+                tombstoned.insert(pk.clone());
+                continue;
+            }
+
+            let entry = rows.entry(pk.clone()).or_insert_with(|| ResolvedRow {
+                pk,
+                columns: std::collections::HashMap::new(),
+            });
+            if let Some(v) = row.val {
+                entry.columns.insert(cid, v);
+            }
+        }
+
+        Ok(rows
+            .into_iter()
+            .filter(|(pk, _)| !tombstoned.contains(pk))
+            .map(|(_, r)| r)
+            .collect())
+    }
+
+    // ── catch-up scans ───────────────────────────────────────────────────
+
+    /// Return every shadow entry whose `db_version` is strictly greater
+    /// than `since`, sorted by `(db_version, seq)` for deterministic
+    /// replay order.
+    ///
+    /// Drives version-vector catch-up: a peer that asks "send me changes
+    /// since N" gets exactly the entries written after N, mapped back into
+    /// `ColumnChange`s ready to be wrapped in a `SyncChangeset` and
+    /// pushed.
+    ///
+    /// Implementation is a full scan + filter — IndexedDB lacks an index
+    /// on the `db_version` payload field, and adding one would require a
+    /// schema migration. Fine for the sizes the demo handles; production
+    /// browser apps with large shadow tables would want to add an index
+    /// and a migration that uses it.
+    pub async fn get_changes_since(
+        &self,
+        since: u64,
+    ) -> Result<Vec<crate::messages::ColumnChange>, StoreError> {
+        use crate::messages::{ColumnChange, ColumnName, NodeId, PrimaryKey, TableName};
+
+        let tx = self
+            .db
+            .transaction(&[STORE_SHADOW], TransactionMode::ReadOnly)?;
+        let store = tx.object_store(STORE_SHADOW)?;
+        let keys: Vec<JsValue> = store.get_all_keys(None, None)?.await?;
+        let values: Vec<JsValue> = store.get_all(None, None)?.await?;
+        tx.commit()?.await?;
+
+        if keys.len() != values.len() {
+            return Err(StoreError::Idb(format!(
+                "shadow scan returned {} keys but {} values",
+                keys.len(),
+                values.len()
+            )));
+        }
+
+        let mut out: Vec<ColumnChange> = Vec::new();
+        for (k_js, v_js) in keys.into_iter().zip(values.into_iter()) {
+            let key = match k_js.as_string() {
+                Some(s) => s,
+                None => continue,
+            };
+            let parts: Vec<&str> = key.splitn(3, '|').collect();
+            if parts.len() != 3 {
+                continue;
+            }
+            let row: ShadowRow = serde_wasm_bindgen::from_value(v_js)
+                .map_err(|e| StoreError::Serde(e.to_string()))?;
+            if row.db_version <= since {
+                continue;
+            }
+            out.push(ColumnChange {
+                table: TableName(parts[0].to_string()),
+                pk: PrimaryKey(parts[1].to_string()),
+                cid: ColumnName(parts[2].to_string()),
+                val: row.val,
+                site_id: NodeId(row.site_id),
+                col_version: row.col_version,
+                cl: row.cl,
+                seq: row.seq,
+                db_version: row.db_version,
+            });
+        }
+
+        // Deterministic replay order: by db_version (the batch the write
+        // belonged to on the originator) then by seq (position within
+        // that batch). This matches the native engine's get_changes_since
+        // ordering so a peer migrating between transports won't see a
+        // different replay shape.
+        out.sort_by_key(|c| (c.db_version, c.seq));
+        Ok(out)
+    }
+
+    // ── peer versions ────────────────────────────────────────────────────
+
+    /// Record the highest `db_version` seen from `peer_id`.
+    ///
+    /// Written on every successful incoming Push and on every catch-up
+    /// response, so the next [`Self::get_peer_version`] returns an
+    /// accurate "I last saw you at N" for the catch-up request.
+    pub async fn set_peer_version(&self, peer_id: &str, version: u64) -> Result<(), StoreError> {
+        let tx = self
+            .db
+            .transaction(&[STORE_PEER_VERSIONS], TransactionMode::ReadWrite)?;
+        let store = tx.object_store(STORE_PEER_VERSIONS)?;
+        let js_val =
+            serde_wasm_bindgen::to_value(&version).map_err(|e| StoreError::Serde(e.to_string()))?;
+        store
+            .put(&js_val, Some(&JsValue::from_str(peer_id)))?
+            .await?;
+        tx.commit()?.await?;
+        Ok(())
+    }
+
+    /// Read the persisted `last seen db_version` for `peer_id`. Returns
+    /// `0` for unknown peers — same convention as the native protocol,
+    /// where `your_last_db_version=0` means "send me everything you have."
+    pub async fn get_peer_version(&self, peer_id: &str) -> Result<u64, StoreError> {
+        let tx = self
+            .db
+            .transaction(&[STORE_PEER_VERSIONS], TransactionMode::ReadOnly)?;
+        let store = tx.object_store(STORE_PEER_VERSIONS)?;
+        let result = store.get(JsValue::from_str(peer_id))?.await?;
+        tx.commit()?.await?;
+        match result {
+            Some(v) if !v.is_null() && !v.is_undefined() => {
+                let n: u64 = serde_wasm_bindgen::from_value(v)
+                    .map_err(|e| StoreError::Serde(e.to_string()))?;
+                Ok(n)
+            }
+            _ => Ok(0),
+        }
+    }
+}
+
+fn shadow_key(table: &str, pk: &str, cid: &str) -> String {
+    format!("{table}|{pk}|{cid}")
+}

--- a/website/Cargo.toml
+++ b/website/Cargo.toml
@@ -7,3 +7,13 @@ publish = false
 [dependencies]
 dioxus = { version = "0.7.6", features = ["web", "router"] }
 pulldown-cmark = { version = "0.10", default-features = false, features = ["html"] }
+# Browser/wasm32 build of wavesyncdb. Exposes the pure-data sync surface,
+# the WebSocket-backed WebSyncClient, and the IndexedDB-backed
+# BrowserStore. The libp2p TCP/QUIC/mDNS engine and sea-orm connection
+# wrapper are gated out for wasm32 in the crate itself.
+wavesyncdb = { workspace = true, features = ["web", "dioxus"] }
+# Used by the todo demo to generate task UUIDs (`crypto.getRandomValues`)
+# and read `Date.now()` for sortable timestamps. Both are wasm-only —
+# the website is wasm-only too.
+getrandom = { version = "0.2", features = ["js"] }
+js-sys = "0.3"

--- a/website/assets/main.css
+++ b/website/assets/main.css
@@ -802,6 +802,487 @@ img {
     flex-wrap: wrap;
 }
 
+/* ── two-device demo layout ─────────────────────────────────── */
+
+.local-demo-grid {
+    display: grid;
+    grid-template-columns: minmax(220px, 320px) minmax(0, 1fr);
+    column-gap: 64px;
+    align-items: start;
+    justify-items: center;
+}
+
+/* ── device frames ──────────────────────────────────────────── */
+
+/* Laptop is the primary "big screen" of the demo — fills its column up
+   to a generous cap so the task list has real estate to breathe. The
+   16:11 aspect ratio gives the screen the proportions of an actual
+   laptop (close to MacBook 16:10 / Surface 3:2). */
+.device-laptop {
+    width: 100%;
+    max-width: 760px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    margin: 0 auto;
+}
+.device-laptop-screen {
+    width: 100%;
+    border: 10px solid #2a3242;
+    border-radius: 16px 16px 4px 4px;
+    background: var(--bg);
+    padding: 22px 24px;
+    box-shadow: 0 16px 48px -18px rgba(0, 0, 0, 0.7);
+    aspect-ratio: 16 / 10;
+    display: flex;
+    flex-direction: column;
+}
+.device-laptop-stand {
+    height: 10px;
+    width: 70%;
+    background: #2a3242;
+    border-radius: 0 0 6px 6px;
+}
+.device-laptop-base {
+    height: 8px;
+    width: 100%;
+    background: #1c222d;
+    border-radius: 0 0 16px 16px;
+    margin-top: -1px;
+}
+
+/* ── phone frame ──── */
+.device-phone {
+    width: 100%;
+    max-width: 280px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+}
+.device-phone-screen {
+    width: 100%;
+    border: 10px solid #2a3242;
+    border-radius: 36px;
+    background: var(--bg);
+    padding: 22px 14px 14px;
+    box-shadow: 0 12px 40px -16px rgba(0, 0, 0, 0.6);
+    aspect-ratio: 9 / 17;
+    display: flex;
+    flex-direction: column;
+    position: relative;
+}
+.device-phone-screen::before {
+    /* Notch — cosmetic only */
+    content: "";
+    position: absolute;
+    top: 6px;
+    left: 50%;
+    transform: translateX(-50%);
+    width: 60px;
+    height: 14px;
+    background: #2a3242;
+    border-radius: 0 0 10px 10px;
+}
+
+/* ── per-device internals ──── */
+.device-label {
+    font-family: var(--font-mono);
+    font-size: 0.75rem;
+    color: var(--text-dim);
+    text-transform: uppercase;
+    letter-spacing: 1.5px;
+    margin-bottom: 8px;
+}
+.device-status {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    font-family: var(--font-mono);
+    font-size: 0.7rem;
+    color: var(--text-muted);
+    margin-bottom: 10px;
+}
+.device-status-dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background: var(--text-dim);
+}
+.device-status-dot.on {
+    background: var(--accent);
+    box-shadow: 0 0 0 3px var(--accent-soft);
+}
+.device-status-dot.offline {
+    background: var(--warning);
+    box-shadow: 0 0 0 3px rgba(247, 200, 124, 0.18);
+}
+.device-status {
+    display: flex !important;
+    align-items: center;
+    gap: 8px;
+}
+.device-toggle {
+    background: transparent;
+    color: var(--text-muted);
+    border: 1px solid var(--border-strong);
+    border-radius: var(--radius-sm);
+    padding: 3px 8px;
+    font-family: var(--font-mono);
+    font-size: 0.7rem;
+    cursor: pointer;
+    transition: color 120ms ease, border-color 120ms ease;
+}
+.device-toggle:hover {
+    color: var(--accent);
+    border-color: var(--accent);
+}
+.device-laptop-screen.offline,
+.device-phone-screen.offline {
+    border-color: #4a3d22;
+    background: linear-gradient(180deg, var(--bg) 0%, #1a1610 100%);
+}
+.device-laptop-screen.offline::after,
+.device-phone-screen.offline::after {
+    content: "OFFLINE";
+    position: absolute;
+    top: 8px;
+    right: 12px;
+    font-family: var(--font-mono);
+    font-size: 0.6rem;
+    color: var(--warning);
+    letter-spacing: 1.5px;
+    pointer-events: none;
+}
+.device-laptop-screen,
+.device-phone-screen {
+    position: relative;
+}
+
+/* Inside the larger laptop screen, scale up the task UI so the frame
+   doesn't look like it's full of tiny phone-sized text. The phone keeps
+   its compact styling. */
+.device-laptop-screen .device-task {
+    font-size: 0.95rem;
+    padding: 9px 12px;
+    gap: 10px;
+}
+.device-laptop-screen .device-task input[type="checkbox"] {
+    width: 17px;
+    height: 17px;
+}
+.device-laptop-screen .device-task-delete {
+    width: 24px;
+    height: 24px;
+    font-size: 1rem;
+}
+.device-laptop-screen .device-add-row input {
+    padding: 9px 12px;
+    font-size: 0.95rem;
+}
+.device-laptop-screen .device-add-row button {
+    padding: 9px 16px;
+    font-size: 0.9rem;
+}
+.device-laptop-screen .device-status {
+    margin-bottom: 14px;
+    font-size: 0.78rem;
+}
+.device-tasks {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    flex: 1;
+    overflow-y: auto;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    min-height: 0;
+}
+.device-task {
+    display: grid;
+    grid-template-columns: auto 1fr auto;
+    align-items: center;
+    gap: 8px;
+    padding: 6px 8px;
+    background: var(--bg-elev);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    font-size: 0.85rem;
+}
+.device-task.done .device-task-title {
+    color: var(--text-dim);
+    text-decoration: line-through;
+}
+.device-task input[type="checkbox"] {
+    accent-color: var(--accent);
+    width: 14px;
+    height: 14px;
+    margin: 0;
+    cursor: pointer;
+}
+.device-task-title {
+    color: var(--text);
+    word-break: break-word;
+    line-height: 1.3;
+}
+.device-task-delete {
+    background: transparent;
+    border: none;
+    color: var(--text-dim);
+    width: 20px;
+    height: 20px;
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 0.85rem;
+    line-height: 1;
+    padding: 0;
+}
+.device-task-delete:hover {
+    color: var(--warning);
+}
+.device-add-row {
+    display: flex;
+    gap: 6px;
+    margin-top: 10px;
+    flex-shrink: 0;
+}
+.device-add-row input {
+    flex: 1;
+    padding: 6px 10px;
+    background: var(--bg-elev);
+    border: 1px solid var(--border-strong);
+    border-radius: var(--radius-sm);
+    color: var(--text);
+    font-family: inherit;
+    font-size: 0.85rem;
+    min-width: 0;
+}
+.device-add-row input:focus {
+    outline: none;
+    border-color: var(--accent);
+}
+.device-add-row button {
+    padding: 6px 10px;
+    background: var(--accent);
+    color: #06231f;
+    border: none;
+    border-radius: var(--radius-sm);
+    font-weight: 600;
+    cursor: pointer;
+    font-size: 0.85rem;
+}
+.device-empty {
+    color: var(--text-dim);
+    font-style: italic;
+    text-align: center;
+    padding: 16px 8px;
+    font-size: 0.85rem;
+}
+.device-meta {
+    margin-top: 10px;
+    padding-top: 8px;
+    border-top: 1px solid var(--border);
+    font-family: var(--font-mono);
+    font-size: 0.7rem;
+    color: var(--text-dim);
+    text-align: center;
+}
+
+@media (max-width: 900px) {
+    .local-demo-grid {
+        grid-template-columns: 1fr;
+        gap: 24px;
+    }
+    .device-phone,
+    .device-laptop {
+        max-width: 100%;
+    }
+}
+
+/* ── todo demo ──────────────────────────────────────────────── */
+
+.demo-grid {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) 320px;
+    gap: 32px;
+    align-items: start;
+}
+.demo-main {
+    background: var(--bg-elev);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 24px;
+    min-height: 320px;
+}
+.demo-side {
+    display: grid;
+    gap: 16px;
+}
+.demo-card {
+    background: var(--bg-elev);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 20px;
+}
+.demo-card h3 {
+    margin-top: 0;
+    margin-bottom: 12px;
+    font-size: 0.95rem;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    color: var(--text-muted);
+}
+.demo-card label {
+    display: block;
+    font-size: 0.85rem;
+    color: var(--text-muted);
+    margin-bottom: 4px;
+    margin-top: 10px;
+}
+.demo-card input[type="text"],
+.demo-card input[type="password"] {
+    width: 100%;
+    padding: 8px 10px;
+    background: var(--bg);
+    border: 1px solid var(--border-strong);
+    border-radius: var(--radius-sm);
+    color: var(--text);
+    font-family: inherit;
+    font-size: 0.95rem;
+}
+.demo-card input[type="text"]:focus,
+.demo-card input[type="password"]:focus {
+    outline: none;
+    border-color: var(--accent);
+}
+.demo-status {
+    margin-top: 12px;
+    padding: 10px 12px;
+    background: var(--bg);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    font-family: var(--font-mono);
+    font-size: 0.82rem;
+    color: var(--text-muted);
+    word-break: break-all;
+}
+.demo-status .demo-status-dot {
+    display: inline-block;
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    margin-right: 8px;
+    vertical-align: middle;
+    background: var(--text-dim);
+}
+.demo-status.demo-status-on .demo-status-dot {
+    background: var(--accent);
+    box-shadow: 0 0 0 3px var(--accent-soft);
+}
+.demo-add-row {
+    display: flex;
+    gap: 8px;
+    margin-bottom: 20px;
+}
+.demo-add-row input {
+    flex: 1;
+    padding: 10px 12px;
+    background: var(--bg);
+    border: 1px solid var(--border-strong);
+    border-radius: var(--radius-sm);
+    color: var(--text);
+    font-size: 1rem;
+    font-family: inherit;
+}
+.demo-add-row input:focus {
+    outline: none;
+    border-color: var(--accent);
+}
+.demo-tasks {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+.demo-task {
+    display: grid;
+    grid-template-columns: auto 1fr auto;
+    align-items: center;
+    gap: 12px;
+    padding: 10px 14px;
+    background: var(--bg);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+}
+.demo-task input[type="checkbox"] {
+    accent-color: var(--accent);
+    width: 18px;
+    height: 18px;
+    cursor: pointer;
+}
+.demo-task-title {
+    color: var(--text);
+    word-break: break-word;
+}
+.demo-task.done .demo-task-title {
+    color: var(--text-dim);
+    text-decoration: line-through;
+}
+.demo-task-meta {
+    font-family: var(--font-mono);
+    font-size: 0.7rem;
+    color: var(--text-dim);
+    margin-top: 2px;
+}
+.demo-task-delete {
+    background: transparent;
+    border: 1px solid var(--border);
+    color: var(--text-dim);
+    width: 28px;
+    height: 28px;
+    border-radius: var(--radius-sm);
+    cursor: pointer;
+    font-size: 0.9rem;
+}
+.demo-task-delete:hover {
+    color: var(--warning);
+    border-color: var(--warning);
+}
+.demo-empty {
+    text-align: center;
+    color: var(--text-dim);
+    padding: 32px 16px;
+    font-style: italic;
+}
+.demo-tip {
+    background: var(--accent-soft);
+    border: 1px solid var(--accent);
+    border-radius: var(--radius-sm);
+    padding: 12px 14px;
+    color: var(--text);
+    font-size: 0.9rem;
+}
+.demo-tip strong {
+    color: var(--accent-strong);
+}
+.demo-error {
+    background: rgba(247, 200, 124, 0.08);
+    border: 1px solid var(--warning);
+    color: var(--warning);
+    padding: 10px 12px;
+    border-radius: var(--radius-sm);
+    font-size: 0.85rem;
+    margin-top: 12px;
+}
+
+@media (max-width: 800px) {
+    .demo-grid {
+        grid-template-columns: 1fr;
+    }
+}
+
 /* ── responsive ─────────────────────────────────────────────── */
 
 @media (max-width: 920px) {

--- a/website/content/docs/01-introduction.md
+++ b/website/content/docs/01-introduction.md
@@ -1,0 +1,45 @@
+# Introduction
+
+**WaveSyncDB** is a transparent peer-to-peer sync layer for SeaORM applications.
+
+You write your app the way you always have — `#[derive(DeriveEntityModel)]` entities, `ActiveModel::insert(&db)`, the usual SeaORM idioms — and WaveSyncDB makes every write replicate to every peer without changing a line of business logic. Conflicts are resolved automatically using per-column Lamport clocks, so concurrent edits to different columns of the same row both survive and every peer converges to the same final state.
+
+## What you get
+
+- A drop-in **`WaveSyncDb`** that implements SeaORM's `ConnectionTrait`. Swap your `DatabaseConnection` for it and continue writing normal SeaORM code.
+
+> **License**: WaveSyncDB is dual-licensed. **AGPL-3.0-or-later** is free for use in AGPL-compatible open-source projects. A separate **commercial license** is available for proprietary, closed-source, or SaaS products. See [Licensing](#licensing) at the bottom of this page.
+
+- **Per-column conflict resolution** — concurrent updates to different columns survive; same-column conflicts resolve deterministically using `(col_version → value bytes → site_id)` total ordering.
+- **Local-first by design** — every write hits SQLite first, so the UI never blocks on the network. Sync is opportunistic in the background.
+- **P2P over libp2p** — mDNS for the LAN, AutoNAT + circuit relay for WAN, DCUtR hole-punching for direct connections when both sides are reachable.
+- **First-class mobile** — a relay server can fan out silent FCM and APNs pushes that wake sleeping phones so they catch up within seconds of a desktop write.
+- **Group authentication** — a shared passphrase derives the topic and signs every message via HMAC-BLAKE3. Anything unauthenticated is silently dropped.
+
+## When to use it
+
+WaveSyncDB is a good fit when:
+
+- You want offline-first behaviour for a desktop or mobile app.
+- The data is **owned by a small group** of users (collaborators, family, your own devices) rather than being public/multi-tenant.
+- You'd rather avoid running a central API tier just to keep a few clients in sync.
+- You're already happy with SeaORM and SQLite.
+
+It is not a good fit for fan-out to thousands of unrelated clients, for adversarial multi-tenant scenarios, or for cases where you need a single authoritative central database.
+
+## What's next
+
+- [Quickstart](/docs/quickstart) — get a running app in under five minutes.
+- [Architecture](/docs/architecture) — how writes propagate end to end.
+- [Conflict resolution](/docs/conflict-resolution) — why per-column CRDTs converge.
+
+## Licensing
+
+WaveSyncDB is **dual-licensed**:
+
+- **AGPL-3.0-or-later** — free for use in AGPL-compatible open-source projects. If your derivative work is itself released under AGPL, no further action is required. AGPL extends copyleft to network use: running a modified WaveSyncDB (or its relay) as a hosted service obliges you to offer the source to remote users.
+- **Commercial license** — required if you are building proprietary, closed-source, or SaaS software and do not want to release your application source under the AGPL — including modifications to a network-facing relay or backend.
+
+For commercial licensing, contact **pablo13vazquez@gmail.com**. Pricing is negotiated per agreement based on use, scale, and support level.
+
+The full text lives in `LICENSE`, `LICENSE-AGPL`, and `LICENSE-COMMERCIAL` in the repository.

--- a/website/content/docs/02-installation.md
+++ b/website/content/docs/02-installation.md
@@ -1,0 +1,119 @@
+# Installation
+
+WaveSyncDB targets stable Rust 1.85+ (edition 2024) and works on Linux, macOS, Windows, Android, and iOS.
+
+## Pick your features
+
+The library is split into [Cargo features](https://doc.rust-lang.org/cargo/reference/features.html) so you only pay for what you use.
+
+| Feature | Pulls in | When to enable |
+|---|---|---|
+| _(default)_ | core sync engine, libp2p, SeaORM connection wrapper | always |
+| `derive` | the `#[derive(SyncEntity)]` proc macro | almost always — required for entity auto-discovery |
+| `dioxus` | reactive hooks: `use_synced_table`, `use_synced_row`, `use_wavesync_init` | UI apps using Dioxus |
+| `push-sync` | mobile FFI + the `background_sync` entry point | Android/iOS apps that wake on FCM/APNs push |
+| `mobile-ffi` | C ABI bindings used by native push handlers | implied by `push-sync`; rarely set directly |
+
+Pick the smallest set that matches your application:
+
+```toml
+# A typical desktop app with reactive UI
+[dependencies]
+wavesyncdb = { version = "0.5", features = ["derive", "dioxus"] }
+
+# A cross-platform desktop + mobile app
+[dependencies]
+wavesyncdb = { version = "0.5", features = ["derive", "dioxus", "push-sync"] }
+
+# Headless service (no UI)
+[dependencies]
+wavesyncdb = { version = "0.5", features = ["derive"] }
+```
+
+## Companion crates
+
+| Crate | Purpose | Required? |
+|---|---|---|
+| [`sea-orm`](https://crates.io/crates/sea-orm) | the ORM you write your entities against | yes |
+| [`tokio`](https://crates.io/crates/tokio) | async runtime | yes |
+| [`wavesyncdb_derive`](https://crates.io/crates/wavesyncdb_derive) | proc macro (re-exported via `derive` feature) | recommended |
+| [`wavesync_relay`](https://crates.io/crates/wavesync_relay) | relay server for WAN sync | only when you need WAN |
+| [`uuid`](https://crates.io/crates/uuid) | string primary keys | recommended |
+
+```toml
+[dependencies]
+sea-orm = { version = "2.0.0-rc", features = ["sqlx-sqlite", "runtime-tokio", "macros"] }
+tokio = { version = "1", features = ["full"] }
+uuid = { version = "1", features = ["v4"] }
+```
+
+## Platform-specific notes
+
+### Linux / macOS / Windows desktop
+
+No system dependencies beyond a C compiler and OpenSSL development headers (which `sqlx` uses transitively). On most distros these are pre-installed; otherwise:
+
+```bash
+# Debian / Ubuntu
+sudo apt install build-essential libssl-dev pkg-config
+
+# Fedora / RHEL
+sudo dnf install gcc openssl-devel pkgconfig
+
+# macOS — Xcode Command Line Tools cover everything
+xcode-select --install
+```
+
+### Android
+
+Use `dx` (the Dioxus CLI) for cross-compilation. The `examples/dioxus_fcm_sync` sample shows the full setup including FCM service registration:
+
+```bash
+cargo install dioxus-cli --locked
+cd your-project
+dx serve --platform android --device
+```
+
+You'll need:
+
+- **Android SDK + NDK** (typically via Android Studio).
+- **`google-services.json`** in your project root if you want push notifications.
+- API level **24+** (the relay-client behaviours require relatively modern TLS APIs).
+
+### iOS
+
+```bash
+dx serve --platform ios --device
+```
+
+You'll need:
+
+- **Xcode 15+** with the iOS 16 SDK.
+- An **Apple Developer account** (free tier works for sideloading; paid is required for App Store + APNs in production).
+- Push entitlements configured in `Dioxus.toml`. See [Mobile & push notifications](/docs/mobile-and-push).
+
+### Embedded / WASM in the browser
+
+Browser WASM is **not currently supported** as a runtime target for the engine itself. The libp2p stack assumes a Tokio runtime with native TCP/UDP sockets, and WaveSyncDB depends on SeaORM + SQLite which are `no_std`-incompatible. Use the library on a desktop / mobile / server target and have the browser talk to it over HTTP if you need a web frontend.
+
+## Verify
+
+After adding the dependency and building, run the tiniest possible smoke test:
+
+```rust
+use wavesyncdb::WaveSyncDbBuilder;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let _ = env_logger::try_init();
+    let _db = WaveSyncDbBuilder::new("sqlite::memory:", "smoketest")
+        .build()
+        .await?;
+    println!("WaveSyncDB engine started.");
+    Ok(())
+}
+```
+
+You should see libp2p log lines indicating the engine has started and is listening for peers. If you instead see compile errors complaining about missing features, double-check the `features = [...]` list above.
+
+Next: [Quickstart](/docs/quickstart).

--- a/website/content/docs/03-quickstart.md
+++ b/website/content/docs/03-quickstart.md
@@ -1,0 +1,103 @@
+# Quickstart
+
+Get a sync-aware SeaORM app running in under five minutes.
+
+## 1. Add the dependencies
+
+```toml
+[dependencies]
+wavesyncdb = { version = "0.5", features = ["derive"] }
+sea-orm = { version = "2.0.0-rc", features = ["sqlx-sqlite", "runtime-tokio", "macros"] }
+tokio = { version = "1", features = ["full"] }
+```
+
+If you're using Dioxus, also enable the `dioxus` feature:
+
+```toml
+wavesyncdb = { version = "0.5", features = ["derive", "dioxus"] }
+```
+
+## 2. Define a SeaORM entity
+
+Add `#[derive(SyncEntity)]` so WaveSyncDB can auto-discover it:
+
+```rust
+use sea_orm::entity::prelude::*;
+use wavesyncdb_derive::SyncEntity;
+
+#[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel, SyncEntity)]
+#[sea_orm(table_name = "tasks")]
+pub struct Model {
+    #[sea_orm(primary_key, auto_increment = false)]
+    pub id: String,
+    pub title: String,
+    pub completed: bool,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {}
+
+impl ActiveModelBehavior for ActiveModel {}
+```
+
+## 3. Build the connection
+
+```rust
+use sea_orm::*;
+use wavesyncdb::WaveSyncDbBuilder;
+
+#[tokio::main]
+async fn main() -> Result<(), DbErr> {
+    let db = WaveSyncDbBuilder::new("sqlite:./app.db?mode=rwc", "my-app-topic")
+        .build()
+        .await?;
+
+    db.get_schema_registry(module_path!().split("::").next().unwrap())
+        .sync()
+        .await?;
+
+    let task = task::ActiveModel {
+        id: Set("1".into()),
+        title: Set("Buy milk".into()),
+        completed: Set(false),
+        ..Default::default()
+    };
+    task.insert(&db).await?;
+    Ok(())
+}
+```
+
+That's it. Run two instances of this binary on the same LAN — each one writes to its own SQLite file, but both databases stay in sync via mDNS-discovered peers.
+
+## 4. Add a passphrase (recommended)
+
+By default, any peer on the same topic can read and write. To restrict your sync mesh to a specific group, add a passphrase:
+
+```rust
+let db = WaveSyncDbBuilder::new("sqlite:./app.db?mode=rwc", "my-app-topic")
+    .with_passphrase("super-secret-shared-string")
+    .build()
+    .await?;
+```
+
+The passphrase is hashed into the topic (so peers without it can't even discover yours) and is used as the HMAC key on every message.
+
+## 5. Add WAN sync (optional)
+
+For sync across networks (cellular ↔ home Wi-Fi, etc.), point your peers at a relay server:
+
+```rust
+let db = WaveSyncDbBuilder::new("sqlite:./app.db?mode=rwc", "my-app-topic")
+    .with_passphrase("...")
+    .with_relay_server("/ip4/203.0.113.10/udp/4001/quic-v1")
+    .build()
+    .await?;
+```
+
+See [Relay deployment](/docs/relay-deployment) for how to host one.
+
+## Where to go from here
+
+- [Dioxus integration](/docs/dioxus-integration) — reactive hooks for UI apps.
+- [Mobile & push notifications](/docs/mobile-and-push) — wake sleeping phones via FCM/APNs.
+- [API reference](/docs/api-reference) — the public types.

--- a/website/content/docs/04-architecture.md
+++ b/website/content/docs/04-architecture.md
@@ -1,0 +1,75 @@
+# Architecture
+
+WaveSyncDB sits between your application code and SeaORM. From your code's perspective it's a `ConnectionTrait`. Underneath, every write is parsed, recorded in a shadow table, and dispatched to a libp2p engine that fans the change out to peers.
+
+## The write path
+
+```mermaid
+flowchart TD
+    App["App writes via SeaORM<br/>task.insert(&db).await?"]
+    App --> Wrapper["WaveSyncDb<br/>(ConnectionTrait wrapper)"]
+    Wrapper -->|"executes SQL"| SQLite[("Local SQLite")]
+    Wrapper -->|"updates"| Shadow[("_wavesync_*_clock<br/>per-column Lamport clocks")]
+    Wrapper -->|"dispatches SyncChangeset"| Engine["libp2p engine"]
+    Wrapper -->|"broadcasts"| Notif["ChangeNotification"]
+    Engine -->|"real-time fan-out"| RemotePeers["Remote peers"]
+    Engine -.->|"catch-up via version vector"| RemotePeers
+    Notif --> ReactiveUI["Reactive UI<br/>(Dioxus signals re-render)"]
+```
+
+The local write commits before any network I/O. If every peer is unreachable, your application keeps working — the change waits in the shadow table until a peer reconnects and asks for it.
+
+## Two sync paths
+
+### Real-time fan-out
+
+```mermaid
+sequenceDiagram
+    participant A as Peer A
+    participant B as Peer B
+    A->>A: local write commits
+    A->>B: SyncRequest::Push(changeset)
+    B->>B: verify HMAC, check topic
+    B->>B: apply_remote_changeset() in txn
+    B-->>A: SyncResponse::PushAck
+```
+
+Each local write produces a `SyncChangeset` that is sent to every currently-connected peer via libp2p's request-response protocol. Receivers verify the HMAC, check the topic matches, then call `apply_remote_changeset()` and respond with `PushAck`. This is the fast path for live collaboration: typically <100 ms when peers are directly connected.
+
+### Catch-up via version vector
+
+```mermaid
+sequenceDiagram
+    participant A as Peer A
+    participant B as Peer B
+    Note over A,B: A reconnects after partition (or 30 s tick)
+    A->>B: VersionVector { my=42, your_last=37, topic, hmac }
+    B->>B: SELECT * FROM shadow WHERE db_version > 37
+    B-->>A: ChangesetResponse { changes, my_db_version=50 }
+    A->>A: verify HMAC, apply in txn
+    A->>A: peer_versions[B] = 50
+```
+
+A new peer with no entry in `_wavesync_peer_versions` sends `your_last_db_version = 0`, which the receiver interprets as "give me everything". This is the only initial-state-transfer mechanism — there is no separate snapshot protocol.
+
+## Shadow tables
+
+For each synced table `tasks`, WaveSyncDB creates `_wavesync_tasks_clock` with primary key `(pk, cid)` (row id + column id). Each row records the column's current value, its Lamport clock (`col_version`), and the site id of the last writer.
+
+The shadow table is what makes per-column conflict resolution work, what lets a peer answer "give me everything since version N" with a fast indexed query, and what lets WaveSyncDB resume sync correctly after a restart (because `db_version` is also persisted on every increment).
+
+See [Schema & registration](/docs/schema) for the exact shadow-table schema.
+
+## What you don't have to think about
+
+- **Connection management** — the engine handles dial loops, reconnection, NAT traversal, and relay reservations.
+- **Schema migration timing** — `get_schema_registry().sync()` creates entity tables and shadow tables atomically before the engine accepts inbound writes.
+- **Ordering** — peers can apply changesets in any order; the per-column total ordering ensures everyone converges.
+- **Idempotency** — duplicate deliveries are no-ops; the shadow-table comparison rejects equal-or-stale incoming changes.
+
+## Further reading
+
+- [Sync protocol](/docs/sync-protocol) — the wire format and message types.
+- [Conflict resolution](/docs/conflict-resolution) — the deterministic ordering that makes convergence work.
+- [Networking & discovery](/docs/networking) — how peers find each other.
+- [API reference](/docs/api-reference) — the types you actually call.

--- a/website/content/docs/05-sync-protocol.md
+++ b/website/content/docs/05-sync-protocol.md
@@ -1,0 +1,166 @@
+# Sync protocol
+
+This page is the protocol-level deep dive. If you only want to use the library, the [Architecture](/docs/architecture) overview is enough — read this when you're debugging a sync bug, building a non-Rust client, or curious about the wire format.
+
+## Two complementary paths
+
+WaveSyncDB runs **two** sync paths in parallel. They serve different purposes and are both required for correct convergence.
+
+| Path | Trigger | Latency | What it solves |
+|---|---|---|---|
+| **Real-time fan-out** | every local write | ~10–100 ms (LAN), ~200–800 ms (WAN) | live collaboration: peers see each other's edits as they happen |
+| **Catch-up via version vector** | peer connect, periodic interval | one round trip | a peer that was offline gets everything it missed in a single batch |
+
+Without real-time fan-out, peers would have to wait up to one sync interval (default 30 s) to see each other's writes. Without catch-up, a peer that misses a single fan-out (e.g., it was disconnected for 50 ms) would be permanently inconsistent until the next write.
+
+## Real-time fan-out
+
+When you call `task.insert(&db).await?`, WaveSyncDB:
+
+1. Executes the SQL on the local SQLite (synchronously, so the call returns the same way SeaORM normally returns).
+2. Parses the SQL to extract column-value pairs.
+3. Increments `db_version` in `_wavesync_meta`.
+4. Writes one row per changed column into the table's shadow table with the new `(col_version, value_bytes, site_id)`.
+5. Builds a `SyncChangeset` and pushes it onto the engine mpsc.
+6. The engine signs the changeset (HMAC-BLAKE3 if a passphrase is set), then sends it via libp2p **request-response** to every currently-connected peer.
+7. Each receiver verifies HMAC, checks the topic matches, calls `apply_remote_changeset` in a transaction, and replies `PushAck`.
+
+```mermaid
+sequenceDiagram
+    participant App
+    participant DB as WaveSyncDb
+    participant Eng as libp2p engine
+    participant Peer
+    App->>DB: task.insert(&db).await?
+    DB->>DB: write to SQLite
+    DB->>DB: update shadow table (col_version + 1)
+    DB-->>App: Ok(model)
+    DB->>Eng: SyncChangeset on mpsc
+    Eng->>Peer: SyncRequest::Push(changeset)
+    Peer->>Peer: verify HMAC, apply in txn
+    Peer-->>Eng: SyncResponse::PushAck
+```
+
+The local write is **already committed** before the network step starts. If every peer is unreachable, your application keeps working — the change waits in the shadow table until catch-up delivers it.
+
+## Catch-up via version vector
+
+When a peer reconnects (or every `sync_interval`, default 30 s), each peer asks each connected peer:
+
+> *"I'm at `db_version = 42`. Last time we talked, you were at `db_version = 37`. What have you got that's newer than 37?"*
+
+The receiver replies with every changeset newer than that version. After applying them, the requester writes `_wavesync_peer_versions[remote_site_id] = remote_db_version` so the next round can pick up where this one ended.
+
+```mermaid
+sequenceDiagram
+    participant A as Peer A (db_version=42)
+    participant B as Peer B (db_version=50)
+    A->>B: SyncRequest::VersionVector { my=42, your_last=37, topic, hmac }
+    B->>B: SELECT * FROM shadow WHERE db_version > 37
+    B-->>A: SyncResponse::ChangesetResponse { changes, my_db_version=50 }
+    A->>A: verify HMAC, apply changes in txn
+    A->>A: peer_versions[B] = 50
+```
+
+A new peer with no entry in `_wavesync_peer_versions` sends `your_last_db_version = 0`, which the receiver interprets as "give me everything". This is the only initial-state-transfer mechanism — there is no separate snapshot protocol.
+
+## Wire format
+
+All messages are JSON for ease of debugging — performance critical work happens at the SQLite layer, not the wire. Each request-response message is length-prefixed:
+
+| Protocol | Prefix | Why |
+|---|---|---|
+| `/wavesync/snapshot/2.0` (catch-up + push) | 4-byte **big-endian** | matches libp2p convention |
+| `/wavesync/auth/2.0` (challenge handshake) | 4-byte **little-endian** | legacy, predates the snapshot protocol |
+
+These prefix encodings **must match** between peers — a peer that sees the wrong endianness will reject the message. The protocol identifier strings are how peers discover whether they speak compatible versions: a mismatch means the request-response handler refuses the substream and the connection survives but doesn't sync.
+
+## Message types
+
+### `SyncRequest`
+
+```rust
+enum SyncRequest {
+    /// Catch-up question.
+    VersionVector {
+        my_db_version: u64,
+        your_last_db_version: u64,
+        site_id: NodeId,
+        topic: TopicString,
+        hmac: HmacTag,
+    },
+    /// Real-time fan-out: "here's a fresh changeset, please apply".
+    Push(SyncChangeset),
+}
+```
+
+### `SyncResponse`
+
+```rust
+enum SyncResponse {
+    ChangesetResponse {
+        changes: Vec<SyncChangeset>,
+        my_db_version: u64,
+    },
+    PushAck,
+    Reject(String), // topic mismatch, HMAC fail, schema unknown, ...
+}
+```
+
+### `SyncChangeset`
+
+```rust
+struct SyncChangeset {
+    table: TableName,
+    primary_key: PrimaryKey,
+    write_kind: WriteKind, // Insert | Update | Delete
+    column_changes: Vec<ColumnChange>,
+    db_version: u64,
+    site_id: NodeId,
+    topic: TopicString,
+    hmac: HmacTag,
+}
+```
+
+### `ColumnChange`
+
+```rust
+struct ColumnChange {
+    column: ColumnName,
+    value: Option<Vec<u8>>, // None for tombstones / unset columns
+    col_version: u64,        // Lamport clock for this (row, column)
+    site_id: NodeId,         // tiebreaker
+}
+```
+
+Each column has its own `col_version` — that's what makes per-column conflict resolution possible. See [Conflict resolution](/docs/conflict-resolution) for the comparison rules.
+
+## Authentication
+
+When a passphrase is configured, **every** request-response message carries an HMAC-BLAKE3 tag computed over the canonical message bytes. The shared key is `BLAKE3(passphrase)`, identical on every peer in the group.
+
+The HMAC verification is **mandatory on every path** — `Push`, `VersionVector`, and `ChangesetResponse`. Skipping HMAC on any path means a malicious peer can inject changesets via that path. This has been a real bug class in past versions: HMAC was once present on real-time push but missing on the catch-up path, leaving an unauthenticated full-sync vector wide open. The current code verifies on all three.
+
+The HMAC input does **not** include wall-clock time. Peers don't share a clock and including time would break verification under skew. See [Authentication & security](/docs/authentication) for the full threat model.
+
+## Topic isolation
+
+Every message carries a `topic` field. The receiver checks `topic_in_message == my_topic` and silently rejects on mismatch. The topic is added to a permanent `rejected_peers` set so reconnects from that peer don't repeatedly trigger sync attempts.
+
+The topic is derived as `BLAKE3(user_topic || passphrase)` — see [Authentication & security](/docs/authentication).
+
+## What this guarantees
+
+Given the protocol above, two peers in the same topic with the same passphrase **always** converge to the same state, regardless of message arrival order, partitions, restarts, or duplicate deliveries. The proof is straightforward:
+
+1. **Eventual delivery**: catch-up via version vector eventually delivers every change to every peer.
+2. **Deterministic resolution**: per-column conflict resolution is a strict total ordering with no time/random/order dependency, so any set of inputs reduces to a single output.
+3. **Idempotency**: applying the same change twice (e.g., due to a duplicate `Push` and a redundant catch-up) is a no-op — the shadow-table comparison rejects equal-or-stale incoming changes.
+
+If you observe non-convergence in practice, it is a bug in implementation, not a flaw in the protocol. The integration tests under `wavesyncdb/tests/` exercise these properties continuously.
+
+## Where to go from here
+
+- [Architecture](/docs/architecture) — the same content at the conceptual level.
+- [Conflict resolution](/docs/conflict-resolution) — the per-column total ordering.
+- [Authentication & security](/docs/authentication) — passphrase, HMAC, threat model.

--- a/website/content/docs/06-conflict-resolution.md
+++ b/website/content/docs/06-conflict-resolution.md
@@ -1,0 +1,97 @@
+# Conflict resolution
+
+When two peers edit the same data at the same time without seeing each other's writes, both edits land — but the network has to converge to a single state. WaveSyncDB uses **per-column Lamport clocks** with a deterministic tiebreaker to make that happen.
+
+## Per-column instead of per-row
+
+Many sync systems use last-write-wins on the entire row: whoever wrote most recently wins, the other write is discarded. That's lossy by design — if peer A toggles `completed` and peer B edits `title` at the same moment, one of those two updates disappears.
+
+WaveSyncDB tracks every column independently. Concurrent edits to *different* columns of the same row both survive. Only edits to the *same* column conflict, and those resolve deterministically.
+
+```mermaid
+sequenceDiagram
+    participant A as Peer A
+    participant B as Peer B
+    Note over A,B: Both peers offline at start
+    A->>A: title = "Buy milk" (col_version=5)
+    B->>B: completed = true (col_version=5)
+    Note over A,B: Peers reconnect
+    A->>B: ColumnChange(title, "Buy milk", v=5, A)
+    B->>A: ColumnChange(completed, true, v=5, B)
+    Note over A,B: Both peers converge to:<br/>title="Buy milk", completed=true
+```
+
+## The total ordering
+
+For each column, the shadow table records `(col_version, value_bytes, site_id)`. When a remote change arrives, WaveSyncDB compares it against the local entry using strict total ordering:
+
+1. **Higher `col_version` wins.** The Lamport clock is incremented monotonically by every writer, so higher means "happened later in causal order".
+2. **If `col_version` is equal**, compare `value_bytes` lexicographically. Higher bytes win.
+3. **If both are equal**, compare `site_id`. Higher site id wins.
+
+```mermaid
+flowchart TD
+    Start{"Compare incoming<br/>vs local entry"}
+    Start -->|"col_version<br/>differs"| HigherV{"Higher col_version wins"}
+    Start -->|"col_version<br/>equal"| Bytes{"Compare value_bytes<br/>lexicographically"}
+    Bytes -->|"differ"| HigherB{"Higher bytes win"}
+    Bytes -->|"equal"| Site{"Compare site_id"}
+    Site --> HigherS{"Higher site_id wins"}
+    HigherV --> Apply["Apply winner<br/>(may be local — no-op)"]
+    HigherB --> Apply
+    HigherS --> Apply
+```
+
+This ordering is total — for any two changes you can compute the winner with no extra context. It is also deterministic: every peer that sees the same set of changes computes the same winner. No wall-clock time, no random tiebreakers, no peer-arrival-order dependence.
+
+## A worked example: same-column conflict
+
+Consider two peers both editing `title` on row `id="task-1"` while disconnected from each other:
+
+| Step | Peer | Action | Shadow row after |
+|---|---|---|---|
+| 1 | A | `UPDATE tasks SET title='Eggs' WHERE id='task-1'` | `(task-1, title) → ('Eggs', col_version=5, site=A)` |
+| 2 | B | `UPDATE tasks SET title='Bread' WHERE id='task-1'` | `(task-1, title) → ('Bread', col_version=5, site=B)` |
+| 3 | A→B | A sends `ColumnChange(title, 'Eggs', v=5, A)` to B | B compares against its local: `v=5` equal → compare bytes: `'Eggs' < 'Bread'` → B keeps `'Bread'`. No-op. |
+| 4 | B→A | B sends `ColumnChange(title, 'Bread', v=5, B)` to A | A compares against its local: `v=5` equal → compare bytes: `'Bread' > 'Eggs'` → A applies. |
+
+Both peers end at `title='Bread'`. The order in which the two messages arrive doesn't matter — the bytewise tiebreaker gives the same answer either way. This is what "deterministic convergence" looks like.
+
+## Deletes
+
+Deletes are tracked the same way — a delete is a column write that sets a tombstone marker. A configurable `DeletePolicy` per table controls what happens when a delete races a concurrent write:
+
+- **`DeleteWins`** (default) — the row is removed. A re-insert of the same primary key on another peer is rejected. Use for normal CRUD.
+- **`AddWins`** — concurrent writes to a row that's being deleted resurrect it. Useful for shared inboxes where dropping a message is worse than seeing a duplicate.
+
+```rust
+// Set the policy when registering an entity manually:
+use wavesyncdb::messages::DeletePolicy;
+db.get_schema_registry("my_crate")
+    .register_with_policy::<inbox::Entity>(DeletePolicy::AddWins)
+    .sync()
+    .await?;
+```
+
+The `#[derive(SyncEntity)]` macro defaults to `DeleteWins`. To override, register the entity manually instead of relying on auto-discovery.
+
+## Why determinism matters
+
+Any non-deterministic tiebreaker (timestamps, random numbers, "first-seen") means two peers can independently resolve the same conflict to different values. The mesh would never converge — they would keep overwriting each other.
+
+This is why WaveSyncDB **never** uses wall-clock time in conflict resolution. Clock skew between phones, laptops, and servers is enough to break convergence. Lamport clocks plus byte-level tiebreaking is the smallest deterministic system that solves the problem.
+
+## What you'll see in practice
+
+- **Both columns updated concurrently** → both survive.
+- **Same column, different values** → the deterministic winner is applied; everyone agrees.
+- **Same column, same value** → idempotent; no-op.
+- **Long offline period** → on reconnect, the version vector replays everything that was missed in one round trip.
+- **A peer crashes mid-write** → since shadow + entity update + version increment happen in one transaction, you never end up with a half-applied write that survives the restart.
+
+You don't write any of this code. The library does it for you behind `task.insert(&db).await?`.
+
+## Where to go from here
+
+- [Schema & registration](/docs/schema) — the shadow-table schema.
+- [Sync protocol](/docs/sync-protocol) — how column changes ride the wire.

--- a/website/content/docs/07-authentication.md
+++ b/website/content/docs/07-authentication.md
@@ -1,0 +1,118 @@
+# Authentication & security
+
+WaveSyncDB ships with **group authentication** — a single shared passphrase grants membership to a sync mesh. This page documents how that works, what threat model it covers, and where the limits are.
+
+## The two layers
+
+| Layer | Mechanism | Stops |
+|---|---|---|
+| **Topic isolation** | derived topic via `BLAKE3(user_topic ‖ passphrase)` | unrelated peers ever attempting to talk to each other |
+| **Message authentication** | HMAC-BLAKE3 over every request-response message | impostors injecting changes after a peer joins the topic |
+
+Both are required. Topic isolation alone is brittle (an attacker who guesses the topic could write whatever they want); HMAC alone leaks topic membership. Together, peers without the passphrase cannot even discover other peers in the mesh, let alone influence them.
+
+## How the topic is derived
+
+```rust
+let derived_topic = blake3(format!("{user_topic}\0{passphrase}").as_bytes());
+```
+
+The derived topic — not the raw `user_topic` you pass to `WaveSyncDbBuilder::new()` — is what's:
+
+- announced via mDNS service records,
+- registered against in libp2p rendezvous,
+- carried in the `topic` field of every sync message.
+
+Two consequences:
+
+1. **Two apps that happen to share a `user_topic` string but use different passphrases are completely isolated.** They can run on the same LAN without seeing each other.
+2. **An attacker scanning mDNS sees opaque BLAKE3 hashes**, not the raw application topic. They can detect *that* a WaveSyncDB-style app is running but not which one.
+
+## How HMAC is computed
+
+Every `SyncRequest`, `SyncResponse`, and `SyncChangeset` carries an `HmacTag` field. The signing process:
+
+1. Serialise the message with the `hmac` field set to a deterministic placeholder (32 zero bytes).
+2. Compute `tag = blake3_keyed(key = blake3(passphrase), data = serialized_bytes)`.
+3. Replace the placeholder with the tag and send.
+
+Verification on the receiver mirrors this exactly. If the tag doesn't match, the message is **silently dropped** — no error response is returned, because returning one would let an attacker probe for valid topics.
+
+```mermaid
+sequenceDiagram
+    participant A as Peer A
+    participant B as Peer B
+    A->>A: serialize(msg with hmac=0)
+    A->>A: tag = HMAC-BLAKE3(key, bytes)
+    A->>B: msg with hmac=tag
+    B->>B: serialize(msg with hmac=0)
+    B->>B: expected = HMAC-BLAKE3(key, bytes)
+    alt tag == expected
+        B->>B: apply changeset
+    else
+        B->>B: drop silently (no response)
+    end
+```
+
+## Why HMAC is on every path
+
+When a passphrase is set, HMAC verification is **non-optional** on:
+
+- real-time `Push` messages (changesets),
+- catch-up `VersionVector` queries,
+- catch-up `ChangesetResponse` replies.
+
+Skipping verification on any one of these is enough to bypass authentication entirely. A peer that authenticates the live push path but trusts catch-up unconditionally is wide open: an attacker just sends a `VersionVector` query, gets the full database back, and then sends a fake `ChangesetResponse` to inject arbitrary state. The fact that the live path is signed is irrelevant — the catch-up path *is* a full-sync vector.
+
+This has been a real bug class in past versions of similar software (and in earlier WaveSyncDB development before the catch-up HMAC was wired up). The current implementation enforces HMAC across all three message kinds in tests.
+
+## What HMAC does NOT include
+
+The HMAC input is exactly the canonical serialization of the message's content fields. It deliberately excludes:
+
+- **Wall-clock time.** Peers' clocks drift by minutes (and across timezones, by hours) — including time would mean valid messages randomly fail to verify under skew. Replay protection comes from the per-column Lamport clocks: an attacker replaying an old `SyncChangeset` produces a no-op, because the existing local clock already dominates.
+- **The HMAC tag field itself.** That's the placeholder pattern above.
+- **libp2p transport metadata** (peer IDs, multiaddrs). Those are authenticated separately by Noise on the libp2p connection layer.
+
+## Threat model
+
+### What this protects against
+
+- ✅ **Eavesdroppers on the same LAN** can't decrypt or inject — TLS-equivalent privacy comes from libp2p's Noise transport, applied to every connection.
+- ✅ **Other apps on the same network** with their own WaveSyncDB instances and different passphrases. Topic isolation makes them invisible to each other.
+- ✅ **Replay attacks** via stale changesets. The Lamport-clock-driven conflict resolution ignores anything older than the current local state.
+- ✅ **A peer being kicked out** of the group. Rotate the passphrase: old peers lose access immediately on the next sync.
+
+### What this does NOT protect against
+
+- ❌ **A compromised passphrase.** Anyone holding the passphrase has full read/write access to the mesh. Treat it like a database password.
+- ❌ **A malicious peer inside the group.** WaveSyncDB has no notion of "read-only" or "scoped" access. Every authenticated peer can write anything to any synced table. This is by design — the model is "small group of trusted devices", not "untrusted multi-tenant".
+- ❌ **Side channels.** A passive observer can measure traffic volume and timing. They can infer when a sync is happening even if they can't read its content.
+- ❌ **Compromised endpoints.** If an attacker gets root on a peer device, they get the database. WaveSyncDB does not encrypt SQLite at rest.
+
+## Choosing a passphrase
+
+- Use a randomly generated string at least 128 bits of entropy. `openssl rand -base64 32` is fine. Don't use a memorable word.
+- Pass it through your app's secret-management layer — `keyring` on desktop, `EncryptedSharedPreferences` / `Keychain` on mobile.
+- Rotating the passphrase requires every peer to update simultaneously. There is no graceful rotation protocol.
+
+## What if I don't set a passphrase?
+
+If you call `WaveSyncDbBuilder::new(url, topic).build()` with no `with_passphrase(...)`, you get:
+
+- **No HMAC** on messages.
+- **No `\0passphrase` mixed into the topic** — the raw topic string is hashed alone.
+- **Anyone on the topic** can read and write the database.
+
+This is appropriate for:
+
+- Development and testing on isolated networks.
+- Public, read-only datasets where there's no value in restricting writers.
+- Scenarios where libp2p's transport-layer Noise is enough and the application doesn't care about topic squatting.
+
+It is **not** appropriate for any user-data-bearing production app on a shared network.
+
+## See also
+
+- [Sync protocol](/docs/sync-protocol) — the wire-format details that HMAC covers.
+- [Networking & discovery](/docs/networking) — what mDNS / rendezvous / relay see in the topic field.

--- a/website/content/docs/08-networking.md
+++ b/website/content/docs/08-networking.md
@@ -1,0 +1,134 @@
+# Networking & discovery
+
+How does a fresh peer find the others? WaveSyncDB layers four discovery mechanisms, each filling a different gap.
+
+```mermaid
+flowchart TD
+    Start([New peer starts]) --> mDNS{Same LAN?}
+    mDNS -- yes --> Direct[Direct dial via mDNS]
+    mDNS -- no --> Rendezvous{Rendezvous server?}
+    Rendezvous -- yes --> Reg[Register topic, query peers]
+    Reg --> NAT{Both peers public?}
+    Rendezvous -- no --> Fallback
+    NAT -- yes --> Direct2[Direct dial]
+    NAT -- no --> AutoNAT[AutoNAT confirms private]
+    AutoNAT --> Relay[Reserve circuit on relay]
+    Relay --> CircuitDial[Dial peer via circuit relay]
+    CircuitDial --> DCUtR{DCUtR can hole-punch?}
+    DCUtR -- yes --> Upgrade[Upgrade to direct connection]
+    DCUtR -- no --> StayRelay[Stay on relay path]
+    Fallback[Fallback: stay isolated] --> End([Sync starts when peers found])
+    Direct --> End
+    Direct2 --> End
+    Upgrade --> End
+    StayRelay --> End
+```
+
+## Layer 1 — mDNS (LAN)
+
+The first layer is **multicast DNS** (`libp2p-mdns`). The engine periodically broadcasts a `_wavesync._udp.local.` query and listens for responses. Every WaveSyncDB peer on the same broadcast domain hears it and responds with its peer ID and listen addresses.
+
+mDNS is enabled by default. You don't have to do anything to use it — two peers on the same Wi-Fi network find each other within ~5 seconds of starting.
+
+```rust
+let db = WaveSyncDbBuilder::new("sqlite:./app.db?mode=rwc", "my-topic")
+    .with_mdns_query_interval(Duration::from_secs(5)) // default
+    .with_mdns_ttl(Duration::from_secs(120))           // default
+    .build()
+    .await?;
+```
+
+mDNS limits:
+
+- Doesn't cross VLANs / subnets / VPN tunnels.
+- Some Wi-Fi APs (especially "guest" networks) **isolate clients** so peers can't see each other even on the same subnet.
+- Mobile foreground services on Android need a `WifiManager.MulticastLock` to read multicast packets — handled by the FCM example service.
+
+## Layer 2 — Rendezvous (WAN, with a known server)
+
+For WAN sync without a relay, peers can register their identity and listen addresses against a **rendezvous server** (just another libp2p node running the rendezvous protocol — typically the same machine that runs your relay).
+
+```rust
+let db = WaveSyncDbBuilder::new(url, "my-topic")
+    .with_rendezvous_server("/ip4/203.0.113.10/udp/4001/quic-v1/p2p/12D3...")
+    .with_rendezvous_discover_interval(Duration::from_secs(60))
+    .with_rendezvous_ttl(7200)
+    .build()
+    .await?;
+```
+
+The server doesn't relay traffic; it only answers "who else is registered against this topic?" Each peer then attempts to dial the others directly.
+
+## Layer 3 — Circuit relay (WAN, behind NAT)
+
+When peers can't connect directly (the common case for two phones on cellular), they fall back to **circuit relay v2**. Each peer reserves a circuit slot on the relay server, gets back a multiaddr like:
+
+```
+/ip4/203.0.113.10/udp/4001/quic-v1/p2p/12D3.../p2p-circuit/p2p/12D3...peer
+```
+
+…and other peers dial that. Traffic flows through the relay, but only the encrypted libp2p stream — the relay can't read or modify it (Noise terminates end to end).
+
+Reserving a circuit takes ~500 ms after AutoNAT confirms `NatStatus::Private`. The reservation is renewed periodically (default 600 s / 10 min in the relay's `MAX_RESERVATION_DURATION_SECS`).
+
+## Layer 4 — DCUtR direct upgrade
+
+Once a circuit is established, the engine attempts a **DCUtR hole-punch** (Direct Connection Upgrade through Relay). If both peers can guess each other's external NAT mapping, they negotiate a direct UDP/QUIC connection alongside the relay path and migrate traffic to it.
+
+DCUtR succeeds when:
+
+- ✅ both peers are behind **cone NAT** (most home routers).
+- ✅ both peers have AutoNAT-confirmed externals.
+- ❌ fails on **symmetric NAT** (most cellular carriers using CGNAT). Sync continues to work via the circuit relay; the relay log will show `DCUtR: direct connection upgrade failed (expected on symmetric-NAT cellular)`.
+
+When DCUtR succeeds, latency drops from ~150 ms (relay round trip) to ~30 ms (direct round trip), and bandwidth use on your relay drops to zero.
+
+## AutoNAT — confirming reachability
+
+Before reserving a relay circuit, a peer needs to know whether it's actually behind NAT (otherwise the reservation is wasteful). **AutoNAT v2** asks other peers "can you dial me at these addresses?" The answer determines `NatStatus::{Public, Private, Unknown}`.
+
+- **`Public`** — skip relay reservation, advertise direct addresses.
+- **`Private`** — reserve a circuit on the configured relay.
+- **`Unknown`** — keep probing.
+
+This sequence is deliberate. Reserving a circuit before AutoNAT confirms private status causes connection failures that don't retry cleanly. The state machine is: `Connecting → Connected → (AutoNAT confirms Private) → Listening`.
+
+## Bootstrap peers
+
+For testing, debugging, or to skip discovery entirely, you can hard-code peer multiaddrs:
+
+```rust
+let db = WaveSyncDbBuilder::new(url, "my-topic")
+    .with_bootstrap_peer("/ip4/192.168.1.50/udp/4001/quic-v1/p2p/12D3...")
+    .build()
+    .await?;
+```
+
+The engine dials each bootstrap peer at startup and adds them to its address book. Bootstrap addresses are also surfaced in FCM payloads so a phone wakeup can dial the writer directly without waiting for relay discovery.
+
+## Transport choice
+
+WaveSyncDB uses **QUIC over UDP** as its sole transport. Earlier versions also offered TCP, but maintaining two transports caused real issues:
+
+- **Two connections per peer** — every dial succeeded twice (once per transport), confusing the relay-client behaviour and breaking circuit-relay dials with `oneshot canceled` on cellular.
+- **Cold-start latency** — TCP added a ~37 ms three-way handshake before TLS could begin; QUIC fuses transport + TLS into one round trip.
+- **Mobile NATs** — many cellular carriers do better with UDP than TCP; QUIC's connection-id model also survives IP-address changes (e.g., Wi-Fi → cellular handoff) without a reconnect.
+
+If you need to reach a peer on a network that blocks UDP, you'll need a relay server with a TCP-base multiaddr. The `EXTERNAL_ADDRESS` env var on `wavesync_relay` accepts a comma-separated list of multiaddrs; deploying one with both TCP and QUIC bases gives clients a fallback.
+
+## Network-change handling
+
+Mobile devices switch networks all the time (Wi-Fi → cellular, cellular → Wi-Fi handoff between APs). When this happens, the engine:
+
+1. Detects the change via OS callbacks.
+2. Calls `network_transition()` internally, which restarts listeners on the new interface.
+3. Re-runs identify on every existing connection so peers pick up the new external address.
+4. Re-reserves circuit relays if the NAT state changed.
+
+The `with_push_listen_addr_updates(true)` config in `behaviour.rs` ensures other peers learn the new address within seconds, instead of staying stuck on the stale one until the next reconnect.
+
+## Where to go from here
+
+- [Relay deployment](/docs/relay-deployment) — host your own relay + rendezvous server.
+- [Mobile & push notifications](/docs/mobile-and-push) — wake sleeping phones via FCM/APNs, then pick a discovery layer.
+- [Configuration reference](/docs/configuration) — every networking knob exposed by the builder.

--- a/website/content/docs/09-schema.md
+++ b/website/content/docs/09-schema.md
@@ -1,0 +1,143 @@
+# Schema & registration
+
+Before WaveSyncDB can sync a table, it needs to know:
+
+1. The table name.
+2. The primary key column.
+3. Every other column (so it can produce per-column shadow rows on every write).
+4. The delete policy (`DeleteWins` vs `AddWins`).
+
+You can give it this metadata explicitly or, more commonly, derive it automatically from your SeaORM entity via `#[derive(SyncEntity)]`.
+
+## The auto-discovery path
+
+```rust
+use sea_orm::entity::prelude::*;
+use wavesyncdb_derive::SyncEntity;
+
+#[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel, SyncEntity)]
+#[sea_orm(table_name = "tasks")]
+pub struct Model {
+    #[sea_orm(primary_key, auto_increment = false)]
+    pub id: String,
+    pub title: String,
+    pub completed: bool,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {}
+
+impl ActiveModelBehavior for ActiveModel {}
+```
+
+Then at startup:
+
+```rust
+db.get_schema_registry(module_path!().split("::").next().unwrap())
+    .sync()
+    .await?;
+```
+
+This:
+
+1. Scans the `inventory` registry — every type that derived `SyncEntity` registered itself there at compile time, scoped by crate name.
+2. Filters by the prefix you passed (so libraries don't accidentally pollute the registry).
+3. Creates the entity tables if they don't exist.
+4. Creates the matching shadow tables (`_wavesync_{table}_clock` and `_wavesync_meta`).
+5. Marks the registry as ready, which unblocks the engine from accepting inbound writes.
+
+The `module_path!().split("::").next().unwrap()` trick is just shorthand for "use my own crate's name". You can pass any string literal there.
+
+## The explicit path
+
+For dynamic-schema cases (when tables aren't known at compile time, e.g., user-defined sheets in a spreadsheet app), you can register manually:
+
+```rust
+db.get_schema_registry("my_crate")
+    .register::<task::Entity>()
+    .register::<note::Entity>()
+    .register_local::<settings::Entity>() // exists in DB, NOT replicated
+    .sync()
+    .await?;
+```
+
+Both paths converge — `sync()` always issues the same `CREATE TABLE` + `CREATE TABLE _wavesync_*` statements.
+
+## Local-only tables
+
+`register_local::<E>()` creates the entity table the same way as `register::<E>()` does, but skips the shadow table and tells the connection wrapper to **not intercept writes** for this table. Use it for:
+
+- App settings that are device-specific (theme, last-opened tab).
+- Caches and ephemeral state.
+- Tables that already have their own sync logic.
+
+A write to a local-only table behaves exactly like raw SeaORM — no shadow rows, no broadcast, no fan-out.
+
+## Primary keys
+
+WaveSyncDB requires a primary key. It can be:
+
+- A **string** (UUIDs are a great choice).
+- An **integer** (but **not auto-increment** — see below).
+
+```rust
+#[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel, SyncEntity)]
+#[sea_orm(table_name = "items")]
+pub struct Model {
+    #[sea_orm(primary_key, auto_increment = false)]
+    pub id: String,
+    pub label: String,
+}
+```
+
+### Why not auto-increment?
+
+Auto-increment integer PKs are a problem in any distributed system: two peers offline both insert "next available id" and end up colliding when they reconnect. WaveSyncDB doesn't try to solve this — instead, it asks you to pick a collision-free id scheme yourself. The standard answer is `Uuid::new_v4().to_string()`.
+
+If you have an existing schema with auto-increment PKs and can't change them, you can still use WaveSyncDB, but every peer must own a disjoint id range (e.g., peer A uses 1–999_999, peer B uses 1_000_000–1_999_999). This is fragile; UUIDs are better.
+
+## Composite primary keys
+
+Composite PKs (multiple columns marked `primary_key`) are **not currently supported**. The shadow table assumes a single PK column. If you need them, derive a synthetic single-column PK by concatenating, e.g. `id = format!("{}-{}", customer_id, order_id)`, and store the original components as regular columns.
+
+## Schema migration
+
+When you add or remove columns from an entity:
+
+1. **Adding a column** is safe. Old peers running pre-migration code keep writing with the old schema; the new column reads as NULL on their writes, which is fine.
+2. **Removing a column** is mostly safe but old peers will keep emitting writes for it. The new code will receive those changes and discard them silently (the column doesn't exist locally any more). No data loss, but wasted bandwidth until every peer is upgraded.
+3. **Renaming a column** is **NOT supported in place**. Add the new column, migrate data, eventually drop the old one in a later release.
+4. **Changing a column type** must be handled at the application layer — WaveSyncDB stores values as raw bytes per `DataType` and doesn't enforce type compatibility on the receiver side.
+
+There is no migration version negotiation in the protocol. Schema agreement is your responsibility. In practice, this means: ship a release that's backward-compatible with N-1, wait for everyone to upgrade, then ship N+1 that drops the back-compat shim.
+
+## Shadow tables — what they look like
+
+For each synced table `tasks`, WaveSyncDB creates `_wavesync_tasks_clock`:
+
+```sql
+CREATE TABLE _wavesync_tasks_clock (
+    pk           TEXT NOT NULL,
+    cid          INTEGER NOT NULL,        -- column id, stable per-table mapping
+    col_version  INTEGER NOT NULL,        -- Lamport clock for this (row, column)
+    site_id      BLOB NOT NULL,           -- node id of the last writer
+    value_bytes  BLOB,                    -- raw bytes; NULL = column-level tombstone
+    db_version   INTEGER NOT NULL,        -- monotonic per-DB write counter
+    PRIMARY KEY (pk, cid)
+);
+CREATE INDEX _wavesync_tasks_clock_db_version ON _wavesync_tasks_clock (db_version);
+```
+
+The `(pk, cid)` primary key gives O(log N) per-column lookups for conflict resolution; the `db_version` index makes catch-up `WHERE db_version > N` queries cheap. There is also a single `_wavesync_meta` table that holds the global `db_version` counter and persisted peer-version map.
+
+You don't read or write these tables directly. Treating them as opaque is the contract — schema-internal layout is allowed to change between minor releases.
+
+## Why per-column instead of per-row?
+
+If you used a single timestamp + winner per row (the "last write wins" pattern), concurrent edits to different columns would discard one of them. Per-column conflict resolution preserves both. The cost is roughly N times more shadow rows where N is the average column count — usually 5–15 columns, so 5–15× shadow size. SQLite handles this without breaking a sweat.
+
+## Where to go from here
+
+- [Conflict resolution](/docs/conflict-resolution) — what happens when two peers update the same column at the same time.
+- [Sync protocol](/docs/sync-protocol) — how shadow-table state translates to wire format.
+- [API reference](/docs/api-reference) — `SchemaBuilder`, `TableMeta`, `register_table`.

--- a/website/content/docs/10-dioxus-integration.md
+++ b/website/content/docs/10-dioxus-integration.md
@@ -1,0 +1,78 @@
+# Dioxus integration
+
+WaveSyncDB ships first-class Dioxus hooks behind the `dioxus` feature flag. They give you reactive signals that auto-refresh on every local *and* remote write — no manual subscriptions, no wiring code.
+
+## Setup
+
+```toml
+[dependencies]
+wavesyncdb = { version = "0.5", features = ["derive", "dioxus"] }
+dioxus = "0.7"
+```
+
+## Provide the database to the app
+
+```rust
+use dioxus::prelude::*;
+use wavesyncdb::dioxus::{use_wavesync_init, use_wavesync_provider, use_synced_table};
+
+fn main() {
+    dioxus::launch(App);
+}
+
+fn App() -> Element {
+    use_wavesync_init("sqlite:./app.db?mode=rwc", "my-topic", |db| async move {
+        db.get_schema_registry(module_path!().split("::").next().unwrap())
+            .sync()
+            .await?;
+        Ok(())
+    });
+
+    let db = use_wavesync_provider();
+    let tasks = use_synced_table::<task::Entity>(&db);
+
+    rsx! {
+        for task in tasks.read().iter() {
+            p { "{task.title}" }
+        }
+    }
+}
+```
+
+## The hooks
+
+| Hook | What it does |
+|------|---|
+| `use_wavesync_init(url, topic, setup)` | Builds the `WaveSyncDb`, runs your setup closure, and provides the DB through Dioxus context. Returns `Resource<WaveSyncDb>`. |
+| `use_wavesync_provider()` | Retrieves the DB from context. Use it inside any descendant component. |
+| `use_synced_table::<E>(db)` | Reactive `Signal<Vec<E::Model>>`. Auto-refreshes on every local and remote write to that table. |
+| `use_synced_row::<E>(db, pk)` | Reactive `Signal<Option<E::Model>>`. Useful for detail pages keyed by primary key. |
+
+## What "reactive" means here
+
+WaveSyncDB broadcasts a `ChangeNotification` after every committed write — local or remote. The notification carries the post-write column values, so the hook applies them in place via the auto-derived [`SyncedModel`](/docs/api-reference) impl — **no SeaORM round-trip per notification**. The component re-renders with the new data automatically.
+
+That means a remote peer toggling `completed = true` will refresh the UI on every other peer, immediately, with no glue code on your side and no extra database read on the receiving side.
+
+### Per-hook behaviour
+
+- `use_synced_row(pk)` ignores notifications whose `primary_key` doesn't match. A list view rendering 100 row hooks does **not** wake all of them on every write — only the one whose row actually changed.
+- `use_synced_table` walks its in-memory `Vec<E::Model>`, finds the row by primary key, and patches it in place (or appends on Insert / drops on Delete). The whole-table `find().all()` runs only once, on first mount, and again only as a fallback if the broadcast channel reports `Lagged` (the subscriber missed notifications).
+- If a notification arrives without a payload — for example, after a raw `execute_unprepared(...)` that bypasses the SeaORM ActiveModel path — the hook falls back to a single-row `find_by_id(pk)` query. Even in that case it never re-fetches the whole table.
+
+## Filtering and projections
+
+The hooks return whole rows as a signal. If you need a filtered or projected view, derive it with a normal Dioxus memo:
+
+```rust
+let tasks = use_synced_table::<task::Entity>(&db);
+let pending = use_memo(move || {
+    tasks.read().iter().filter(|t| !t.completed).cloned().collect::<Vec<_>>()
+});
+```
+
+The memo recomputes whenever `tasks` changes, which happens whenever any peer in the mesh writes.
+
+## Background sync on mobile
+
+On mobile, the engine is suspended when the app is backgrounded. To keep data fresh while the app is closed, see [Mobile & push notifications](/docs/mobile-and-push).

--- a/website/content/docs/11-mobile-and-push.md
+++ b/website/content/docs/11-mobile-and-push.md
@@ -1,0 +1,92 @@
+# Mobile & push notifications
+
+When a phone is fully closed, libp2p connections are gone — the OS suspends every process and the sync engine is not running. WaveSyncDB solves this with **silent push notifications**: a relay server sends an FCM (Android) or APNs (iOS) wake signal that runs a one-shot background sync, pulls the latest changes, and shuts down.
+
+The push carries no data. It is just a wake signal — the actual data transfers via the normal sync protocol once the engine is up.
+
+## Architecture
+
+```mermaid
+sequenceDiagram
+    participant D as Desktop
+    participant R as Relay server
+    participant F as FCM / APNs
+    participant P as Phone (asleep)
+    D->>D: write commits locally
+    D->>R: notify_relay_topic(topic, peer_addrs)
+    R->>R: debounce, look up tokens
+    R->>F: silent high-priority push
+    F-->>P: wake (FirebaseMessagingService<br/>or iOS background notification)
+    P->>P: background_sync(database_url, timeout)
+    P->>D: connect via relay or DCUtR-direct
+    D-->>P: SyncResponse with missed changesets
+    P->>P: apply, shut down engine
+```
+
+## What you need
+
+- A relay server. See [Relay deployment](/docs/relay-deployment).
+- An **FCM service-account JSON** (for Android) and/or an **APNs `.p8` key** plus team/key/bundle ids (for iOS).
+- A Firebase project with `google-services.json` configured for your Android app.
+- iOS push entitlements set in your `Dioxus.toml` and a development/production APNs environment.
+
+## Wiring on the client
+
+Enable the `push-sync` feature on `wavesyncdb`:
+
+```toml
+wavesyncdb = { version = "0.5", features = ["derive", "dioxus", "push-sync"] }
+```
+
+That feature pulls in the FFI glue used by the platform-side service to call back into the Rust engine when a push arrives.
+
+The native service (Android `FirebaseMessagingService` or iOS background notification handler) calls `wavesyncdb::background_sync::background_sync(database_url, timeout)`, which:
+
+1. Loads the saved configuration (the same `WaveSyncDbBuilder` settings you used on first launch — written by `WaveSyncDbBuilder::build()` automatically).
+2. Builds a fresh `WaveSyncDb` instance.
+3. Initialises the schema registry.
+4. Waits for peer discovery (mDNS or relay), requests a full sync, and applies incoming changesets.
+5. Returns a `BackgroundSyncResult` and shuts down cleanly.
+
+A typical wake-to-synced round on Wi-Fi takes ~1 second; on cellular via the relay, ~2–3 seconds.
+
+## Wiring on the relay
+
+The relay server reads service credentials from environment variables and listens for push tokens from clients. When a client emits `notify_relay_topic`, the relay looks up every peer registered for that topic and fans out FCM/APNs.
+
+See [Relay deployment](/docs/relay-deployment) for the exact env vars and Dokploy compose file.
+
+## What gets pushed
+
+Pushes are silent and high-priority. They include the topic id and the sender's reachable peer addresses, which lets the receiving phone dial directly instead of waiting for discovery — saving ~500ms per wake.
+
+The phone uses these addresses as bootstrap peers and falls back to the relay's circuit-relay address if the direct dial fails. On symmetric-NAT cellular this is the common case, and the circuit-relay path is reliable.
+
+## Stages of a push-triggered sync
+
+Each call to `background_sync` emits structured log lines at every stage so you can pinpoint where the wall-clock time goes:
+
+| Stage | Typical wall-clock budget | What's happening |
+|---|---|---|
+| `config_loaded` | <50 ms | Reading `wavesync.json` next to the SQLite database |
+| `engine_built` | 100–250 ms | Building the libp2p swarm, opening listening sockets |
+| `registry_ready` | <50 ms | Schema registry initialised |
+| `relay_listening` | 200–500 ms | AutoNAT confirmed private + circuit reservation accepted |
+| `first_peer` | 100 ms (FCM-direct) — 1500 ms (cold) | First peer connection established |
+| `sync_requested` | <10 ms | First catch-up VersionVector sent |
+| `first_peer_synced` | 100–800 ms | Peer responded with changeset, applied locally |
+| `done` | total: 1–3 s on Wi-Fi, 2–4 s on cellular | Engine shut down, result returned |
+
+If a phase consistently takes much longer than this in your deployment, watch the logcat output and open an issue.
+
+## Limits and gotchas
+
+- FCM and APNs both rate-limit silent pushes. WaveSyncDB debounces at the relay (default 1 s) so a burst of writes generates one push, not N.
+- iOS limits silent pushes per app per hour; high-frequency apps should consider explicit user-visible notifications for important events.
+- On Android, `WaveSyncService` acquires a `WifiManager.MulticastLock` while the foreground sync runs so mDNS can race against the relay-introduced direct dial on Wi-Fi.
+- Cold-cache JIT-compiling the Rust binary in the Android background process is slower than the foreground app — add roughly 200 ms to the typical numbers above on the first wake after a phone reboot.
+
+## Further reading
+
+- [Relay deployment](/docs/relay-deployment) — host the relay yourself with one Docker Compose file.
+- [Networking & discovery](/docs/networking) — the discovery layers a phone tries on wake.

--- a/website/content/docs/12-relay-deployment.md
+++ b/website/content/docs/12-relay-deployment.md
@@ -1,0 +1,97 @@
+# Relay deployment
+
+The `wavesync_relay` crate is a small libp2p server that does three things:
+
+1. **Circuit relay v2** — bridges WAN peers behind NATs that can't connect directly.
+2. **Rendezvous discovery** — peers register against a topic and discover each other.
+3. **Push fan-out** — receives `notify_relay_topic` signals and triggers FCM/APNs to wake sleeping phones.
+
+You only need a relay if your peers will be on different networks. LAN-only deployments don't need one — mDNS handles discovery automatically.
+
+## Quick deploy with Docker Compose
+
+A ready-to-deploy `docker-compose.yml` lives under `wavesync_relay/` in the repo. Drop a `.env` next to it:
+
+```env
+EXTERNAL_ADDRESS=/ip4/203.0.113.10/udp/4001/quic-v1,/ip4/203.0.113.10/tcp/4001
+APNS_KEY_ID=ABC123XYZ4
+APNS_TEAM_ID=DEF456UVW7
+APNS_BUNDLE_ID=com.example.myapp
+RUST_LOG=info
+```
+
+Place your secrets next to it under `secrets/`:
+
+```
+secrets/fcm.json      # FCM service-account JSON
+secrets/apns.p8       # APNs signing key (PEM)
+secrets/identity.b64  # base64-encoded libp2p keypair (optional, persists peer id)
+```
+
+Then:
+
+```bash
+docker compose up -d --build
+```
+
+## Deploying to Dokploy
+
+The `docker-compose.yml` is already structured for Dokploy:
+
+1. **Application type:** Docker Compose.
+2. **Source:** this Git repo.
+3. **Compose Path:** `wavesync_relay/docker-compose.yml`.
+4. **Base Directory:** `wavesync_relay`.
+5. **Advanced → Mounts:** add one **File Mount** per secret you use:
+
+   | File path | Mount path | Content |
+   |---|---|---|
+   | `secrets/fcm.json` | `/run/secrets/fcm.json` | FCM service-account JSON |
+   | `secrets/apns.p8` | `/run/secrets/apns.p8` | APNs `.p8` PEM |
+   | `secrets/identity.b64` | `/run/secrets/identity.b64` | base64 identity |
+
+   Dokploy stores these under the project's `files/` folder on the host — leave the compose `volumes:` block minimal so it doesn't conflict.
+
+6. **Environment Variables:** set at minimum `EXTERNAL_ADDRESS`. Add APNs metadata if you use APNs.
+7. Hit **Redeploy** (not Restart) to pick up new mounts.
+
+## Environment variables
+
+| Variable | Required | Notes |
+|---|---|---|
+| `EXTERNAL_ADDRESS` | yes | Public multiaddr clients dial. Comma-separated for multiple transports. |
+| `IDENTITY_KEYPAIR` | no | Inline base64 keypair, or path to a file. Falls back to a generated key under `/data/identity.key`. |
+| `FCM_CREDENTIALS` | no | Inline JSON or file path. Auto-discovered from `/run/secrets/fcm.json`. |
+| `APNS_KEY_FILE` | no | Inline PEM or file path. Auto-discovered from `/run/secrets/apns.p8`. |
+| `APNS_KEY_ID` / `APNS_TEAM_ID` / `APNS_BUNDLE_ID` | conditional | Required when APNs push is enabled. |
+| `PUSH_DB` | no | Path to push token SQLite database. Defaults to `/data/push_tokens.db`. |
+| `MAX_RESERVATIONS` | no | Default `1024`. Bump if you have many phones. |
+| `MAX_RESERVATIONS_PER_PEER` | no | Default `32`. |
+| `RESERVATION_DURATION_SECS` | no | Default `600`. |
+| `RUST_LOG` | no | Standard log filter. `info` is recommended in production. |
+
+## Pointing clients at it
+
+```rust
+let db = WaveSyncDbBuilder::new("sqlite:./app.db?mode=rwc", "my-topic")
+    .with_passphrase("...")
+    .with_relay_server("/ip4/203.0.113.10/udp/4001/quic-v1")
+    .build()
+    .await?;
+```
+
+For managed-relay mode (where the client also registers a push token):
+
+```rust
+let db = WaveSyncDbBuilder::new("sqlite:./app.db?mode=rwc", "my-topic")
+    .with_passphrase("...")
+    .managed_relay("/ip4/203.0.113.10/udp/4001/quic-v1", "your-relay-api-key")
+    .build()
+    .await?;
+```
+
+## Operating notes
+
+- The relay is stateless except for `/data/identity.key` (peer id continuity) and `/data/push_tokens.db` (registered phones). Mount a volume on `/data` so reservations and tokens survive restarts.
+- Health: check the logs for periodic `Reservation accepted` and `Push sent` lines. If you see `ReservationReqDenied { ResourceLimitExceeded }`, raise `MAX_RESERVATIONS_PER_PEER`.
+- The relay can be public; without your shared passphrase, anonymous peers can't decrypt or sign anything they receive.

--- a/website/content/docs/13-configuration.md
+++ b/website/content/docs/13-configuration.md
@@ -1,0 +1,127 @@
+# Configuration reference
+
+This page lists every method on `WaveSyncDbBuilder` and what it controls. The builder follows the standard fluent pattern: every `with_...` returns the builder by value, so you can chain them.
+
+```rust
+WaveSyncDbBuilder::new("sqlite:./app.db?mode=rwc", "my-topic")
+    .with_passphrase("...")
+    .with_relay_server("/ip4/203.0.113.10/udp/4001/quic-v1")
+    .with_sync_interval(Duration::from_secs(30))
+    .with_ipv6(true)
+    .build()
+    .await?
+```
+
+## Required
+
+| Method | Description |
+|---|---|
+| `WaveSyncDbBuilder::new(database_url, topic)` | Database URL (a SeaORM-compatible SQLite URL) and an application topic string. The topic is hashed with the passphrase if one is set; otherwise it's used directly. |
+
+## Authentication
+
+| Method | Default | Notes |
+|---|---|---|
+| `with_passphrase(s: &str)` | none | Enables HMAC on every message and mixes the passphrase into the topic hash. Required for any real-world deployment on a shared network. See [Authentication & security](/docs/authentication). |
+
+## Identity
+
+| Method | Default | Notes |
+|---|---|---|
+| `with_node_id(NodeId)` | random 16-byte UUID, persisted to `_wavesync_meta` | Override the node's site id. Almost never needed — the auto-generated id is stable across restarts. |
+
+## WAN: relay & rendezvous
+
+| Method | Default | Notes |
+|---|---|---|
+| `with_relay_server(addr: &str)` | none | libp2p multiaddr of the circuit-relay server. Required for WAN sync between peers behind NAT. Typical: `/ip4/203.0.113.10/udp/4001/quic-v1/p2p/12D3...` |
+| `managed_relay(addr: &str, api_key: &str)` | none | Same as `with_relay_server` plus push-token registration on the relay. Use for mobile apps that should wake on FCM/APNs. |
+| `with_rendezvous_server(addr: &str)` | none | libp2p multiaddr of the rendezvous server (often the same machine as the relay). Peers register their topic and discover each other through it. |
+| `with_rendezvous_discover_interval(Duration)` | 60 s | How often to query the rendezvous server for new peers. |
+| `with_rendezvous_ttl(seconds: u64)` | 7200 | How long to keep a registration alive on the server. The peer auto-renews before expiry. |
+| `with_bootstrap_peer(addr: &str)` | none (multi-call) | Hard-coded peer multiaddr to dial at startup. Useful for tests; also surfaced in FCM payloads so a phone can dial directly on wake. |
+
+## Network discovery
+
+| Method | Default | Notes |
+|---|---|---|
+| `with_ipv6(enabled: bool)` | `false` | Listen on IPv6 in addition to IPv4. |
+| `with_mdns_query_interval(Duration)` | 5 s | mDNS broadcast frequency. Lower = faster LAN discovery but more multicast traffic. |
+| `with_mdns_ttl(Duration)` | 120 s | How long mDNS-discovered peer addresses stay valid. |
+| `with_keep_alive_interval(Duration)` | 30 s | libp2p `ping` interval — keeps idle connections alive through stateful firewalls. |
+
+## Sync timing
+
+| Method | Default | Notes |
+|---|---|---|
+| `with_sync_interval(Duration)` | 30 s | Periodic catch-up sync interval. Lower = faster catch-up after partition, more network chatter. |
+| `with_circuit_max_duration(Duration)` | 60 min | How long to keep a single circuit-relay connection open before forcing a fresh reservation. |
+
+## Push notifications (mobile)
+
+| Method | Default | Notes |
+|---|---|---|
+| `with_push_token(platform: &str, token: &str)` | none | Pre-set the push token. Usually you don't call this directly — `managed_relay` + the platform-side push handler register the token at runtime. `platform` is `"fcm"` or `"apns"`. |
+| `with_google_services(google_services_json: &str)` | none | Inline contents of `google-services.json` for FCM token retrieval on Android. |
+| `with_fcm(project_id, app_id, api_key)` | none | Lower-level alternative to `with_google_services` if you want to set the three values explicitly. |
+
+## Database directory
+
+The builder writes a small config file (`wavesync.json`) next to the SQLite database. This config records the parameters needed for `background_sync` to reconstruct the connection on a future invocation — see [Mobile & push notifications](/docs/mobile-and-push). The config path is derived from the `database_url`, so as long as your URL is stable across launches, no extra setup is needed.
+
+## Example: typical mobile app
+
+```rust
+let db = WaveSyncDbBuilder::new(
+        "sqlite:./app.db?mode=rwc",
+        "com.example.myapp",
+    )
+    .with_passphrase(&user_group_secret)
+    .managed_relay(
+        "/ip4/203.0.113.10/udp/4001/quic-v1/p2p/12D3KooWRelayPeerIdHere",
+        &relay_api_key,
+    )
+    .with_rendezvous_server(
+        "/ip4/203.0.113.10/udp/4001/quic-v1/p2p/12D3KooWRelayPeerIdHere",
+    )
+    .with_sync_interval(Duration::from_secs(30))
+    .with_ipv6(true)
+    .build()
+    .await?;
+```
+
+## Example: pure LAN, no relay
+
+```rust
+let db = WaveSyncDbBuilder::new("sqlite:./app.db?mode=rwc", "lan-only-topic")
+    .with_passphrase("shared-on-the-fridge-magnet")
+    .with_mdns_query_interval(Duration::from_secs(3))
+    .build()
+    .await?;
+```
+
+## Example: headless service (no UI)
+
+```rust
+let db = WaveSyncDbBuilder::new("sqlite:/var/lib/myapp/state.db?mode=rwc", "service")
+    .with_passphrase(&env::var("WAVESYNC_PASSPHRASE")?)
+    .with_relay_server(&env::var("WAVESYNC_RELAY")?)
+    .with_keep_alive_interval(Duration::from_secs(60))
+    .build()
+    .await?;
+```
+
+## Inspecting state at runtime
+
+After the builder produces a `WaveSyncDb`, useful inspection methods include:
+
+| Method | Returns |
+|---|---|
+| `db.node_id()` | this peer's stable site id |
+| `db.network_status()` | snapshot of currently-connected peers, NAT state, relay status |
+| `db.network_event_rx()` | broadcast receiver of `NetworkEvent`s for reactive UIs |
+| `db.is_engine_alive()` | health check |
+| `db.request_full_sync()` | force an immediate catch-up round |
+| `db.set_peer_identity(app_id)` | label this peer with a human-readable identity (multi-device per-user setups) |
+
+See [API reference](/docs/api-reference) for the full method signatures.

--- a/website/content/docs/14-faq.md
+++ b/website/content/docs/14-faq.md
@@ -1,0 +1,121 @@
+# FAQ & troubleshooting
+
+## When should I *not* use WaveSyncDB?
+
+- **Public, multi-tenant fan-out.** If your data is meant to reach untrusted strangers, this is the wrong tool — every authenticated peer can read and write everything in the topic.
+- **Authoritative central state.** If you need a single source of truth that arbitrates writes (financial transactions, inventory levels), a traditional client-server database with a server-side write API is what you want.
+- **Heavy write throughput** (>1000 writes/s sustained). The protocol is fine for collaborative apps but not optimized for telemetry-style ingest. Use Kafka.
+- **Adversarial peers.** WaveSyncDB has no per-row ACLs. Anyone with the passphrase can write anything.
+
+## Does it work offline?
+
+Yes. The local SQLite write commits before any network step. The change waits in the shadow table until a peer reconnects and asks for it. There is no "online required" mode.
+
+## What happens if I lose the passphrase?
+
+The mesh keeps working for everyone who still has it. A peer that loses the passphrase can:
+
+- Keep using its local SQLite (the data is still there, unencrypted at rest).
+- Re-join only by getting the passphrase back. There is no recovery mechanism.
+
+## Can I rotate the passphrase?
+
+Only by coordinating across every peer simultaneously — the new passphrase changes the topic hash, so old and new peers don't see each other. The recommended sequence is:
+
+1. Deploy a new app version that supports the new passphrase.
+2. Roll out to every peer.
+3. After a confirmation period, drop the old passphrase support.
+
+There is no graceful in-place rotation protocol.
+
+## How do I migrate from raw SeaORM?
+
+Replace `DatabaseConnection` with `WaveSyncDb`:
+
+```diff
+- let db: DatabaseConnection = Database::connect("sqlite:./app.db").await?;
++ let db = WaveSyncDbBuilder::new("sqlite:./app.db?mode=rwc", "my-topic")
++     .build()
++     .await?;
++ db.get_schema_registry(module_path!().split("::").next().unwrap()).sync().await?;
+```
+
+Then add `#[derive(SyncEntity)]` to each entity you want synced. Existing rows get picked up the next time a peer asks for catch-up — they're already in the entity table, so the registry just builds the shadow rows lazily on first write.
+
+## Why aren't my changes appearing on the other peer?
+
+Walk through the layers in order:
+
+1. **Did the local write commit?** Read it back from the same connection — if SeaORM doesn't see it, the write didn't happen.
+2. **Did the engine emit a `SyncChangeset`?** Subscribe to the change broadcast: `db.change_rx().recv().await`. If you don't see a notification, the SQL parser didn't recognize the statement (e.g., a raw `execute()` of a multi-statement script). Check your write pattern.
+3. **Are the peers connected?** Check `db.network_status().connected_peers`. Empty list means peer discovery hasn't completed.
+4. **Same topic + passphrase?** A topic mismatch silently rejects all messages — check both sides.
+5. **HMAC failing?** Enable `RUST_LOG=wavesyncdb=debug` and look for "HMAC verification failed". Almost always a passphrase typo.
+6. **Schema registered on both sides?** A peer that hasn't called `.sync()` yet rejects inbound changes for unknown tables.
+
+## Why is sync slow on cellular?
+
+The slow path is **circuit-relay-based**: cellular CGNAT defeats DCUtR hole-punching, so traffic stays on the relay. Typical numbers:
+
+- Circuit-relay round trip: 100–250 ms.
+- DCUtR direct round trip: 20–60 ms.
+
+If your relay is on a different continent from your users, latency adds up. Move the relay closer.
+
+## Why is FCM background sync sometimes slow?
+
+FCM delivery itself is the bottleneck. Google's "high priority data message" SLA is 5 s but in practice 95th-percentile delivery on Android is often 1.5–3 s, and iOS APNs is similar. Once the push lands, our `background_sync` typically finishes in <2 s on a warm cache, so the visible latency is dominated by Google/Apple infrastructure.
+
+## How big can the database get?
+
+There's no hard limit — SQLite handles tens of GB. The shadow tables grow proportionally to the number of column-writes (not rows), so a write-heavy table grows faster than its read counterpart.
+
+For now there's no shadow-table compaction. If your dataset's write rate is high enough that shadow size becomes a problem, open an issue on GitHub — the data structure was designed to support log compaction; it just hasn't been implemented yet.
+
+## Can I use it without Rust on the other side?
+
+Today, no — the protocol is documented (see [Sync protocol](/docs/sync-protocol)) but the only client implementation is in Rust. A Swift / Kotlin / TypeScript client would need to:
+
+1. Parse the JSON wire format.
+2. Implement libp2p's request-response + Noise + QUIC stack (or use a libp2p port for that language).
+3. Compute HMAC-BLAKE3 the same way.
+4. Manage shadow tables in its local store.
+
+This is non-trivial. Practically, the supported way to use WaveSyncDB on iOS/Android is to compile the Rust crate via FFI and call into it from Swift/Kotlin. The `wavesyncdb_ffi` crate exposes a C ABI for that.
+
+## Can two peers use different SQLite versions?
+
+Yes — the wire format doesn't depend on SQLite version. You can have one peer on SQLite 3.39 and another on 3.45 without issue. WaveSyncDB only requires a SQLite that supports `INSERT OR REPLACE` and indexed views, both standard since 3.0.
+
+## How do I run an integration test against a real network?
+
+The repository's integration tests under `wavesyncdb/tests/` use file-backed temp SQLite databases and process-local peers. They run with `--test-threads=1` because mDNS discovery is process-wide and parallel tests cross-discover. To test against a real LAN, set up two distinct binaries on two machines and use the example apps as a starting point.
+
+## What's the relationship to gossipsub / pub-sub?
+
+Earlier WaveSyncDB versions used libp2p **gossipsub** for fan-out. The current version uses libp2p **request-response** instead, because:
+
+- gossipsub fan-out is best-effort with no per-message acknowledgement, so we needed a separate retry loop on top.
+- request-response gives per-message acks for free, simplifying the protocol.
+- gossipsub adds 30+ KiB per peer of meshing state; request-response adds none.
+
+The trade-off is that very large topics (~100s of peers) would scale better with gossipsub. WaveSyncDB targets small groups, so this isn't a concern.
+
+## Is the relay a single point of failure?
+
+It's a single point of *coordination*, but data integrity doesn't depend on it. If the relay goes down:
+
+- LAN peers (mDNS) keep syncing normally.
+- WAN peers that already have direct connections keep syncing.
+- New WAN peers can't discover or reach others until the relay is back.
+- No data is lost. As soon as the relay returns, catch-up replays everything.
+
+For higher availability, you can run multiple relays — list them all in the `with_relay_server` calls (the engine connects to each); peers will then keep working as long as at least one relay is up.
+
+## Does it support encryption at rest?
+
+Not directly — that's a SQLite concern. Use SQLCipher or filesystem-level encryption if you need it. WaveSyncDB doesn't intercept SQLite writes at the filesystem layer, so SQLCipher integrates transparently.
+
+## Is the project production-ready?
+
+It is in production for the project's primary use case (a small-group collaboration app). The core sync engine, conflict resolution, and Dioxus integration are stable. The relay + push-notification integration is stable but newer; if you deploy at significant scale, expect to find rough edges and please open issues. License + commercial-support agreements are available — see the [License](/docs/introduction#licensing) section.

--- a/website/content/docs/15-benchmarks.md
+++ b/website/content/docs/15-benchmarks.md
@@ -1,0 +1,110 @@
+# Benchmarks
+
+Real numbers, captured from a single machine running both peers in process. We avoid the temptation to compare against other databases — every cross-product comparison invites tuning-fairness arguments. Instead, we measure WaveSyncDB against itself: the cost of the wrapper, the speed of live sync, the throughput of catch-up, and the time to converge under contention.
+
+If you want to reproduce or rerun on your hardware, every binary lives in `examples/bench/` and runs with one `cargo run` invocation each. See [How to reproduce](#how-to-reproduce) at the bottom.
+
+## Hardware and software
+
+| Item | Value |
+|---|---|
+| CPU | 13th Gen Intel® Core™ i7-13700KF (24 logical cores) |
+| Memory | 32 GB |
+| OS | Linux 6.19 (CachyOS) |
+| Rust | 1.92.0 |
+| WaveSyncDB | commit `06232c2` + write-path optimization series (single-tx bookkeeping, batched ON CONFLICT shadow upsert, MAX-derived db_version, inlined dispatch) |
+| Build | `cargo run --release` |
+| Storage | local NVMe, SQLite WAL mode (default) |
+
+## 1. Local write overhead
+
+The cost of routing writes through `WaveSyncDb` instead of a raw SeaORM `DatabaseConnection`. Same SQLite database layout, same `task` entity, same number of ops. Only the connection wrapper differs. No peers configured — this is a pure local-write measurement.
+
+| Operation | Raw SeaORM | WaveSyncDB | Ratio | Per-write overhead |
+|---|---:|---:|---:|---:|
+| `INSERT` | **22 393 ops/s** | **9 690 ops/s** | 0.43× | ~58 µs |
+| `UPDATE` | **28 931 ops/s** | **11 002 ops/s** | 0.38× | ~56 µs |
+| `DELETE` | **28 907 ops/s** | **11 728 ops/s** | 0.41× | ~51 µs |
+
+5 000 ops per measurement. The bookkeeping that adds the overhead — shadow tables, per-column Lamport clocks, the broadcast send — is collapsed into a single SQLite transaction with one batched `ON CONFLICT DO UPDATE … RETURNING` for all changed columns at once. The `db_version` counter recovers from `MAX(shadow.db_version)` on startup, so it doesn't need a per-write `_wavesync_meta` write. Net: **two fsyncs per write** (the entity insert + the shadow tx), regardless of column count.
+
+> **Reading these numbers**: 10 000 writes/s comfortably covers any user-facing CRUD app. WaveSyncDB is not built for telemetry-style ingest — if you need 100k writes/s, use Kafka.
+
+These numbers are post-optimization. An earlier version of WaveSyncDB ran 7.5× slower than raw SeaORM on INSERT (3 700 ops/s); the [write-path rework](https://github.com/pvg13/WaveSyncDB/blob/main/wavesyncdb/src/connection.rs) closed most of that gap.
+
+## 2. Peer-to-peer write latency (LAN)
+
+Two `WaveSyncDb` instances on the same machine, mDNS discovery enabled, separate SQLite files. Peer B subscribes to `change_rx`; we time from `task.insert(&peer_a).await` returning to the matching `ChangeNotification` resolving on Peer B.
+
+| Metric | Latency |
+|---|---:|
+| Mean | **0.43 ms** |
+| p50 | **0.42 ms** |
+| p95 | **0.57 ms** |
+| p99 | **0.77 ms** |
+| max | **1.31 ms** |
+
+100 sequential inserts. The path measured is full end-to-end: parse SQL → shadow table → libp2p `request-response::Push` over loopback → HMAC verify on B → apply transaction → broadcast. Sub-millisecond p50 for live collaboration on the same host.
+
+Real WAN measurements add the round-trip from the network plus the relay if circuit-relayed. Expect ~50–100 ms p50 over the public internet, dominated by the relay round trip.
+
+## 3. Catch-up after offline period
+
+Peer A writes 1 000 rows to its local SQLite. Then Peer B starts cold, mDNS discovers A, and we time the version-vector catch-up until Peer B's local table contains all 1 000 rows.
+
+| Phase | Wall-clock |
+|---|---:|
+| Peer A writes 1 000 rows (no Peer B yet) | 0.11 s |
+| Peer B engine startup | 0.001 s |
+| Catch-up (mDNS discover + VV exchange + apply) | **0.17 s** |
+| **Total time to converged state** | **0.17 s** |
+| **Throughput during catch-up** | **5 933 rows / s** |
+
+A peer that's been offline for any length of time, holding any number of accumulated changes, fully reconciles its state in a single round trip. The 1 000 rows here are arbitrary — the round-trip cost is constant, only the changeset payload size grows.
+
+## 4. Concurrent same-column conflict resolution
+
+Two peers, both updating `tasks.title` on the same row, 250 updates each, in parallel. We time both phases and verify both peers converge to the same final value (correctness assertion).
+
+| Metric | Value |
+|---|---:|
+| Concurrent writes (250 × 2 = 500 total) | 0.07 s |
+| Convergence after writes stop | 0.05 s |
+| **Total wall-clock** | **0.12 s** |
+| **Total throughput** | **4 030 updates / s** |
+| Both peers' final `title` agreed | ✅ identical |
+
+The deterministic `(col_version → value_bytes → site_id)` ordering means no human-visible "merge resolution" is needed — peers reach the same final state regardless of message arrival order.
+
+## How to reproduce
+
+```bash
+git clone https://github.com/pvg13/WaveSyncDB
+cd WaveSyncDB
+
+# Build once (release mode is required for representative numbers)
+cargo build -p wavesyncdb-bench --release
+
+# Run any combination
+cargo run -p wavesyncdb-bench --release --bin bench_overhead
+cargo run -p wavesyncdb-bench --release --bin bench_lan_sync
+cargo run -p wavesyncdb-bench --release --bin bench_catchup
+cargo run -p wavesyncdb-bench --release --bin bench_conflict
+```
+
+Each binary prints a human-readable summary plus a single `BENCH_RESULT: { ... }` JSON line at the end so a CI dashboard can ingest results without scraping the human output. Source: [`examples/bench/`](https://github.com/pvg13/WaveSyncDB/tree/main/examples/bench).
+
+## Caveats and what this does NOT measure
+
+- **Single machine only**. The LAN and catch-up benches use loopback. Real LAN adds switching latency (~0.5 ms p50); cellular via the relay adds 50–200 ms.
+- **No relay in the loop**. WAN benches require a real relay deployment; deferred to a follow-up.
+- **No mobile.** All numbers are from x86_64 Linux. Android / iOS will be slower mainly because of slower disk and the FCM wake-up step.
+- **No memory measurements**. Shadow table size scales with column-writes; for typical CRUD workloads the storage overhead is 5–15× the entity tables, which SQLite handles without breaking a sweat.
+- **Steady state**, not p99.99 tail. The benches don't run long enough to capture once-an-hour stalls (GC-style collection? OS page cache eviction?). For sustained-tail measurement, run continuously and capture a histogram over hours.
+- **Engine startup excluded** from the latency benches but included in catch-up. Cold-start latency (process spawn → engine ready) is ~150–250 ms on x86; we exclude it from steady-state benches because typical apps start once and stay running.
+
+## Where to go from here
+
+- [Sync protocol](/docs/sync-protocol) — what the bytes on the wire actually look like.
+- [Conflict resolution](/docs/conflict-resolution) — why convergence is correct, not just empirically observed.
+- [FAQ & troubleshooting](/docs/faq) — common bottlenecks and how to investigate them.

--- a/website/content/docs/16-api-reference.md
+++ b/website/content/docs/16-api-reference.md
@@ -1,0 +1,95 @@
+# API reference
+
+The public surface is small on purpose. Most apps need only the builder, the connection, and the schema registry — everything else is internal.
+
+## Core types
+
+| Type | Description |
+|---|---|
+| `WaveSyncDb` | SeaORM `ConnectionTrait` wrapper that intercepts writes and dispatches sync. |
+| `WaveSyncDbBuilder` | Fluent builder for configuring and creating a `WaveSyncDb`. |
+| `SchemaBuilder` | Returned by `db.get_schema_registry(crate_name)`. Use `.register::<E>()`, `.register_local::<E>()`, `.sync()`. |
+| `TableMeta` | Metadata for a synced table (name, primary key, columns, delete policy). |
+| `SyncChangeset` | A set of column-level changes with per-column Lamport clocks and site ids. |
+| `ColumnChange` | A single column change: table, primary key, column, value, `col_version`, `site_id`. |
+| `ChangeNotification` | Emitted after every committed local or remote write. |
+| `DeletePolicy` | Per-table policy: `DeleteWins` (default) or `AddWins`. |
+| `WriteKind` | `Insert`, `Update`, `Delete`. |
+| `BackgroundSyncResult` | Result of a one-shot mobile background sync: `Synced { peers_synced }`, `TimedOut { peers_synced }`, `NoPeers`. |
+| `SyncedModel` | Trait auto-derived by `#[derive(SyncEntity)]`. The Dioxus hooks call its `wavesync_apply_change` / `wavesync_from_changes` methods to update signal data from `ChangeNotification.column_values` without a DB round-trip. |
+
+## Builder configuration
+
+```rust
+WaveSyncDbBuilder::new(database_url, topic)
+    .with_passphrase("...")                       // BLAKE3-derives topic + HMAC key
+    .with_relay_server("/ip4/.../udp/4001/quic-v1")
+    .with_rendezvous_server("/ip4/.../udp/4001/quic-v1")
+    .with_bootstrap_peer("/ip4/.../udp/4001/quic-v1/p2p/12D3...")
+    .with_sync_interval(Duration::from_secs(30))
+    .with_ipv6(true)
+    .managed_relay(relay_addr, "api-key")        // sets up FCM/APNs push registration
+    .build()
+    .await?;
+```
+
+## Schema registration
+
+```rust
+db.get_schema_registry(module_path!().split("::").next().unwrap())
+    .sync()                       // auto-discover everything #[derive(SyncEntity)]
+    .await?;
+
+// Or register manually:
+db.get_schema_registry("my_crate")
+    .register::<task::Entity>()
+    .register::<note::Entity>()
+    .register_local::<settings::Entity>()  // table exists but is NOT replicated
+    .sync()
+    .await?;
+```
+
+## Reactive subscriptions
+
+```rust
+let mut events = db.network_event_rx();
+while let Ok(event) = events.recv().await {
+    match event {
+        NetworkEvent::PeerConnected(peer_id) => { /* ... */ }
+        NetworkEvent::PeerSynced { peer_id, .. } => { /* ... */ }
+        NetworkEvent::EngineStarted => { /* first event you'll see */ }
+        _ => {}
+    }
+}
+```
+
+## Dioxus hooks (feature `dioxus`)
+
+| Hook | Returns |
+|---|---|
+| `use_wavesync_init(url, topic, setup)` | `Resource<WaveSyncDb>` |
+| `use_wavesync_provider()` | `WaveSyncDb` from Dioxus context |
+| `use_synced_table::<E>(db)` | `Signal<Vec<E::Model>>` |
+| `use_synced_row::<E>(db, pk)` | `Signal<Option<E::Model>>` |
+
+## Background sync (feature `push-sync`)
+
+```rust
+use wavesyncdb::background_sync::{background_sync, background_sync_with_peers};
+
+let result = background_sync("sqlite:///data/data/com.app/app.db?mode=rwc", Duration::from_secs(30)).await?;
+```
+
+`background_sync_with_peers` accepts a slice of peer multiaddrs (typically delivered in the FCM payload) so the engine dials directly instead of waiting for discovery.
+
+## Errors
+
+WaveSyncDB returns SeaORM's `DbErr` for normal database errors and a small set of crate-specific error types for sync setup failures. Standard `?` propagation works as expected.
+
+## Crate features
+
+| Feature | Effect |
+|---|---|
+| `derive` | Enables `#[derive(SyncEntity)]` from `wavesyncdb_derive`. |
+| `dioxus` | Enables the reactive hooks listed above. |
+| `push-sync` | Enables `background_sync` + the FFI surface used by mobile push handlers. |

--- a/website/src/app.rs
+++ b/website/src/app.rs
@@ -1,7 +1,7 @@
 use dioxus::prelude::*;
 
 use crate::components::{Footer, Nav};
-use crate::pages::{DocPage, Examples, Home, NotFound};
+use crate::pages::{DocPage, Examples, Home, NotFound, SyncDemo, TodoDemo};
 
 const MAIN_CSS: Asset = asset!("/assets/main.css");
 const FAVICON: Asset = asset!("/assets/favicon.svg");
@@ -17,6 +17,10 @@ pub enum Route {
     DocPage { slug: String },
     #[route("/examples")]
     Examples {},
+    #[route("/demo")]
+    TodoDemo {},
+    #[route("/sync-demo")]
+    SyncDemo {},
     #[end_layout]
     #[route("/:..route")]
     NotFound { route: Vec<String> },

--- a/website/src/components/footer.rs
+++ b/website/src/components/footer.rs
@@ -29,7 +29,8 @@ pub fn Footer() -> Element {
                 }
             }
             div { class: "site-footer-bottom",
-                "© 2026 WaveSyncDB contributors"
+                "© 2026 WaveSyncDB contributors · v"
+                {wavesyncdb::VERSION}
             }
         }
     }

--- a/website/src/components/nav.rs
+++ b/website/src/components/nav.rs
@@ -16,6 +16,7 @@ pub fn Nav() -> Element {
                 nav { class: "site-nav-links",
                     Link { class: "site-nav-link", to: Route::DocsIndex {}, "Docs" }
                     Link { class: "site-nav-link", to: Route::Examples {}, "Examples" }
+                    Link { class: "site-nav-link", to: Route::TodoDemo {}, "Demo" }
                     a {
                         class: "site-nav-link site-nav-github",
                         href: "https://github.com/pvg13/WaveSyncDB",

--- a/website/src/pages/home.rs
+++ b/website/src/pages/home.rs
@@ -68,12 +68,10 @@ pub fn Home() -> Element {
                             to: Route::DocPage { slug: "quickstart".to_string() },
                             "Get started →"
                         }
-                        a {
+                        Link {
                             class: "btn btn-secondary",
-                            href: "https://github.com/pvg13/WaveSyncDB",
-                            target: "_blank",
-                            rel: "noopener",
-                            "Star on GitHub"
+                            to: Route::TodoDemo {},
+                            "Try the live demo"
                         }
                     }
                     div { class: "hero-install",
@@ -182,11 +180,17 @@ pub fn Home() -> Element {
             div { class: "section-inner",
                 h2 { class: "cta-title", "Ready to make your app local-first?" }
                 p { class: "cta-subtitle",
-                    "Read the quickstart, clone an example, or jump into the docs."
+                    "Read the quickstart, browse the examples, or kick the tires in your "
+                    "browser — the live demo runs the same engine compiled to wasm32."
                 }
                 div { class: "cta-actions",
                     Link {
                         class: "btn btn-primary",
+                        to: Route::TodoDemo {},
+                        "Try the live demo →"
+                    }
+                    Link {
+                        class: "btn btn-secondary",
                         to: Route::DocPage { slug: "quickstart".to_string() },
                         "Quickstart"
                     }

--- a/website/src/pages/mod.rs
+++ b/website/src/pages/mod.rs
@@ -2,12 +2,48 @@ mod docs;
 mod examples;
 mod home;
 mod not_found;
+
+// `sync_demo` and `todo_demo` use the wasm-only `WebSyncClient`,
+// `BrowserEntity`, `LoopbackPair`, etc. — these are cfg-gated to
+// wasm32 in `wavesyncdb::lib`. The `Route` enum in `app.rs` references
+// the components on every target, so we ship browser-only stubs on
+// native to keep the route table buildable for the dioxus-fullstack
+// server side and `cargo check` runs.
+#[cfg(target_arch = "wasm32")]
 mod sync_demo;
+#[cfg(target_arch = "wasm32")]
 mod todo_demo;
 
 pub use docs::DocPage;
 pub use examples::Examples;
 pub use home::Home;
 pub use not_found::NotFound;
+#[cfg(target_arch = "wasm32")]
 pub use sync_demo::SyncDemo;
+#[cfg(target_arch = "wasm32")]
 pub use todo_demo::TodoDemo;
+
+#[cfg(not(target_arch = "wasm32"))]
+mod browser_only_stubs {
+    use dioxus::prelude::*;
+
+    #[component]
+    pub fn SyncDemo() -> Element {
+        rsx! {
+            div { class: "panel",
+                p { "This demo runs in the browser only — open it in a wasm build." }
+            }
+        }
+    }
+
+    #[component]
+    pub fn TodoDemo() -> Element {
+        rsx! {
+            div { class: "panel",
+                p { "This demo runs in the browser only — open it in a wasm build." }
+            }
+        }
+    }
+}
+#[cfg(not(target_arch = "wasm32"))]
+pub use browser_only_stubs::{SyncDemo, TodoDemo};

--- a/website/src/pages/mod.rs
+++ b/website/src/pages/mod.rs
@@ -2,8 +2,12 @@ mod docs;
 mod examples;
 mod home;
 mod not_found;
+mod sync_demo;
+mod todo_demo;
 
 pub use docs::DocPage;
 pub use examples::Examples;
 pub use home::Home;
 pub use not_found::NotFound;
+pub use sync_demo::SyncDemo;
+pub use todo_demo::TodoDemo;

--- a/website/src/pages/sync_demo.rs
+++ b/website/src/pages/sync_demo.rs
@@ -1,0 +1,218 @@
+//! Browser P2P sync demo page.
+//!
+//! Wires `wavesyncdb::WebSyncClient` into a Dioxus form so a visitor can
+//! point the demo at any libp2p WebSocket-listening peer (typically a
+//! `wavesync-relay` instance running with `--ws-listen-addr`) and see
+//! authenticated CRDT changesets stream in. Doubles as the smoke test
+//! that the `web` feature genuinely links and runs end-to-end in the
+//! browser.
+
+use dioxus::prelude::*;
+use wavesyncdb::{ColumnChange, WebSyncClient, serde_json};
+
+const DEFAULT_RELAY_ADDR: &str = "/dns4/relay.example.com/tcp/443/wss";
+const DEFAULT_TOPIC: &str = "wavesync-web-demo";
+const DEFAULT_STORE_NAME: &str = "demo";
+const DEFAULT_TABLE: &str = "tasks";
+
+#[component]
+pub fn SyncDemo() -> Element {
+    let mut relay_addr = use_signal(|| DEFAULT_RELAY_ADDR.to_string());
+    let mut topic = use_signal(|| DEFAULT_TOPIC.to_string());
+    let mut passphrase = use_signal(String::new);
+    let mut persist = use_signal(|| true);
+    let mut store_name = use_signal(|| DEFAULT_STORE_NAME.to_string());
+
+    let mut status = use_signal(|| "Not connected".to_string());
+    let mut received = use_signal(Vec::<String>::new);
+    let mut client_handle = use_signal(|| None::<WebSyncClient>);
+
+    let mut write_table = use_signal(|| DEFAULT_TABLE.to_string());
+    let mut write_pk = use_signal(|| "task-1".to_string());
+    let mut write_col = use_signal(|| "title".to_string());
+    let mut write_val = use_signal(|| "Buy milk".to_string());
+
+    let on_connect = move |_| {
+        let pp = passphrase();
+        let pp_opt = if pp.is_empty() { None } else { Some(pp) };
+        let addr = relay_addr();
+        let topic_v = topic();
+        let store_n = store_name();
+        let persistent = persist();
+
+        spawn(async move {
+            let result = if persistent {
+                WebSyncClient::connect_persistent(&addr, &topic_v, pp_opt.as_deref(), &store_n)
+                    .await
+            } else {
+                WebSyncClient::connect(&addr, &topic_v, pp_opt.as_deref())
+            };
+
+            match result {
+                Ok(client) => {
+                    status.set(format!(
+                        "Dialing {addr} ({})",
+                        if persistent {
+                            "persistent"
+                        } else {
+                            "ephemeral"
+                        }
+                    ));
+                    let mut rx = client.subscribe_resolved();
+                    spawn(async move {
+                        while let Ok(change) = rx.recv().await {
+                            received.with_mut(|v| v.push(format_change(&change)));
+                        }
+                    });
+                    client_handle.set(Some(client));
+                }
+                Err(e) => status.set(format!("Connect failed: {e}")),
+            }
+        });
+    };
+
+    let on_submit_write = move |_| {
+        if let Some(client) = client_handle() {
+            let table = write_table();
+            let pk = write_pk();
+            let cid = write_col();
+            let val = serde_json::Value::String(write_val());
+            spawn(async move {
+                match client
+                    .submit_local_write(&table, &pk, vec![(cid, val)])
+                    .await
+                {
+                    Ok(dv) => status.set(format!("Wrote, new db_version={dv}")),
+                    Err(e) => status.set(format!("Write failed: {e}")),
+                }
+            });
+        }
+    };
+
+    rsx! {
+        section { class: "page-header",
+            div { class: "section-inner",
+                h1 { class: "page-title", "Browser sync demo" }
+                p { class: "page-subtitle",
+                    "Connects to a libp2p WebSocket peer (typically a wavesync-relay running with "
+                    code { "--ws-listen-addr" }
+                    ") and exchanges authenticated SyncChangesets in real time. "
+                    "When persistence is enabled, identity, db_version, and CRDT shadow state "
+                    "survive page reload via IndexedDB."
+                }
+            }
+        }
+        section { class: "examples-grid-section",
+            div { class: "section-inner",
+                form {
+                    style: "display: grid; gap: 0.75rem; max-width: 640px;",
+                    onsubmit: move |e| e.prevent_default(),
+
+                    h3 { "Connection" }
+                    label { "Peer multiaddr" }
+                    input {
+                        value: "{relay_addr}",
+                        oninput: move |e| relay_addr.set(e.value()),
+                    }
+                    label { "Topic" }
+                    input {
+                        value: "{topic}",
+                        oninput: move |e| topic.set(e.value()),
+                    }
+                    label { "Passphrase (optional)" }
+                    input {
+                        r#type: "password",
+                        value: "{passphrase}",
+                        oninput: move |e| passphrase.set(e.value()),
+                    }
+                    label {
+                        input {
+                            r#type: "checkbox",
+                            checked: persist(),
+                            oninput: move |e| persist.set(e.value() == "true"),
+                        }
+                        " Persist identity + shadow tables in IndexedDB"
+                    }
+                    if persist() {
+                        label { "Store name" }
+                        input {
+                            value: "{store_name}",
+                            oninput: move |e| store_name.set(e.value()),
+                        }
+                    }
+                    button {
+                        r#type: "button",
+                        onclick: on_connect,
+                        "Connect"
+                    }
+
+                    h3 { "Submit local write" }
+                    div { style: "display: grid; gap: 0.5rem; grid-template-columns: 1fr 1fr;",
+                        div {
+                            label { "Table" }
+                            input {
+                                value: "{write_table}",
+                                oninput: move |e| write_table.set(e.value()),
+                            }
+                        }
+                        div {
+                            label { "Primary key" }
+                            input {
+                                value: "{write_pk}",
+                                oninput: move |e| write_pk.set(e.value()),
+                            }
+                        }
+                        div {
+                            label { "Column" }
+                            input {
+                                value: "{write_col}",
+                                oninput: move |e| write_col.set(e.value()),
+                            }
+                        }
+                        div {
+                            label { "Value" }
+                            input {
+                                value: "{write_val}",
+                                oninput: move |e| write_val.set(e.value()),
+                            }
+                        }
+                    }
+                    button {
+                        r#type: "button",
+                        onclick: on_submit_write,
+                        disabled: client_handle().is_none(),
+                        "Submit local write (bumps versions, persists, broadcasts)"
+                    }
+
+                    p { "Status: " strong { "{status}" } }
+                    div {
+                        h3 { "Resolved remote changes" }
+                        if received().is_empty() {
+                            p { em { "(none yet)" } }
+                        } else {
+                            ul {
+                                for line in received().iter() {
+                                    li { "{line}" }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn format_change(c: &ColumnChange) -> String {
+    format!(
+        "{}.{} pk={} col_v={} val={}",
+        c.table.0,
+        c.cid.0,
+        c.pk.0,
+        c.col_version,
+        c.val
+            .as_ref()
+            .map(|v| v.to_string())
+            .unwrap_or_else(|| "<deleted>".into()),
+    )
+}

--- a/website/src/pages/todo_demo.rs
+++ b/website/src/pages/todo_demo.rs
@@ -1,0 +1,382 @@
+//! Self-contained two-device sync demo, WhatsApp-Web-style.
+//!
+//! Each device runs an independent [`WebSyncClient`] with its own
+//! IndexedDB store. The two clients are wired together via
+//! [`LoopbackPair`] — crossed in-process channels that swap
+//! `SyncRequest::Push` envelopes directly, so no relay or network is
+//! required.
+//!
+//! What's deliberately *not* in this file:
+//! - manual `subscribe_resolved` plumbing
+//! - a parallel `HashMap<String, Task>` of in-memory app state
+//! - optimistic-merge logic in the add/toggle/delete handlers
+//!
+//! All of that is now handled by [`use_synced_table`] in wavesyncdb.
+//! IndexedDB is the single source of truth; the component is a thin
+//! renderer over `Signal<Vec<Task>>`.
+
+use std::collections::HashMap;
+
+use dioxus::prelude::*;
+use wavesyncdb::{
+    BrowserEntity, LoopbackLink, LoopbackPair, WebSyncClient, dioxus::use_synced_table, serde_json,
+};
+
+const TOPIC: &str = "wavesync-local-demo";
+const STORE_LAPTOP: &str = "local-demo-laptop";
+const STORE_PHONE: &str = "local-demo-phone";
+const TASK_TABLE: &str = "tasks";
+
+#[derive(Clone, Debug, Default)]
+struct Task {
+    id: String,
+    title: String,
+    done: bool,
+    deleted: bool,
+    created_at: u64,
+}
+
+impl BrowserEntity for Task {
+    fn from_columns(pk: &str, cols: &HashMap<String, serde_json::Value>) -> Self {
+        Task {
+            id: pk.to_string(),
+            title: cols
+                .get("title")
+                .and_then(|v| v.as_str())
+                .unwrap_or("(untitled)")
+                .to_string(),
+            done: cols.get("done").and_then(|v| v.as_bool()).unwrap_or(false),
+            deleted: cols
+                .get("deleted")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false),
+            created_at: cols.get("created_at").and_then(|v| v.as_u64()).unwrap_or(0),
+        }
+    }
+
+    fn to_columns(&self) -> Vec<(String, serde_json::Value)> {
+        vec![
+            (
+                "title".to_string(),
+                serde_json::Value::String(self.title.clone()),
+            ),
+            ("done".to_string(), serde_json::Value::Bool(self.done)),
+            ("deleted".to_string(), serde_json::Value::Bool(self.deleted)),
+            (
+                "created_at".to_string(),
+                serde_json::Value::Number(serde_json::Number::from(self.created_at)),
+            ),
+        ]
+    }
+
+    fn pk(&self) -> String {
+        self.id.clone()
+    }
+}
+
+#[component]
+pub fn TodoDemo() -> Element {
+    // Two clients, one per device, wired through a LoopbackPair.
+    // Everything else lives in the children via `use_synced_table`.
+    let mut laptop = use_signal(|| None::<WebSyncClient>);
+    let mut phone = use_signal(|| None::<WebSyncClient>);
+    let mut laptop_link = use_signal(|| None::<LoopbackLink>);
+    let mut phone_link = use_signal(|| None::<LoopbackLink>);
+    let laptop_online = use_signal(|| true);
+    let phone_online = use_signal(|| true);
+    let mut error_msg = use_signal(|| None::<String>);
+
+    use_hook(move || {
+        spawn(async move {
+            let pair = LoopbackPair::new();
+            laptop_link.set(Some(pair.a.link()));
+            phone_link.set(Some(pair.b.link()));
+
+            match WebSyncClient::connect_loopback(pair.a, TOPIC, None, STORE_LAPTOP).await {
+                Ok(c) => laptop.set(Some(c)),
+                Err(e) => {
+                    error_msg.set(Some(format!("laptop init failed: {e}")));
+                    return;
+                }
+            }
+            match WebSyncClient::connect_loopback(pair.b, TOPIC, None, STORE_PHONE).await {
+                Ok(c) => phone.set(Some(c)),
+                Err(e) => {
+                    error_msg.set(Some(format!("phone init failed: {e}")));
+                }
+            }
+        });
+    });
+
+    rsx! {
+        section { class: "page-header",
+            div { class: "section-inner",
+                h1 { class: "page-title", "Live demo · Two devices, one page" }
+                p { class: "page-subtitle",
+                    "Two independent WaveSyncDB peers running side-by-side in this tab. "
+                    "Each one has its own identity, its own IndexedDB, and its own copy of "
+                    "the task list. They're wired together by an in-process channel — "
+                    "no relay, no network — so you can see the engine doing real work "
+                    "without any setup."
+                }
+                p { class: "page-subtitle",
+                    "Take a device offline to break the link, edit on either side, then "
+                    "bring it back online. The local device replays its buffered edits "
+                    "and asks the peer for everything it missed via a version-vector "
+                    "catch-up. Same protocol the native engine uses over the network."
+                }
+                if let Some(err) = error_msg() {
+                    p { class: "demo-error", "{err}" }
+                }
+            }
+        }
+        section { class: "examples-grid-section",
+            div { class: "section-inner",
+                div { class: "local-demo-grid",
+                    DevicePhone {
+                        client: phone,
+                        link: phone_link,
+                        online: phone_online,
+                    }
+                    DeviceLaptop {
+                        client: laptop,
+                        link: laptop_link,
+                        online: laptop_online,
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[component]
+fn DeviceLaptop(
+    client: Signal<Option<WebSyncClient>>,
+    link: Signal<Option<LoopbackLink>>,
+    online: Signal<bool>,
+) -> Element {
+    rsx! {
+        div { class: "device-laptop",
+            div { class: "device-label", "Laptop · " code { "{STORE_LAPTOP}" } }
+            div {
+                class: if online() { "device-laptop-screen" } else { "device-laptop-screen offline" },
+                DeviceBody {
+                    client,
+                    link,
+                    online,
+                    store_name: STORE_LAPTOP.to_string(),
+                }
+            }
+            div { class: "device-laptop-stand" }
+            div { class: "device-laptop-base" }
+        }
+    }
+}
+
+#[component]
+fn DevicePhone(
+    client: Signal<Option<WebSyncClient>>,
+    link: Signal<Option<LoopbackLink>>,
+    online: Signal<bool>,
+) -> Element {
+    rsx! {
+        div { class: "device-phone",
+            div { class: "device-label", "Phone · " code { "{STORE_PHONE}" } }
+            div {
+                class: if online() { "device-phone-screen" } else { "device-phone-screen offline" },
+                DeviceBody {
+                    client,
+                    link,
+                    online,
+                    store_name: STORE_PHONE.to_string(),
+                }
+            }
+        }
+    }
+}
+
+#[component]
+fn DeviceBody(
+    client: Signal<Option<WebSyncClient>>,
+    link: Signal<Option<LoopbackLink>>,
+    mut online: Signal<bool>,
+    store_name: String,
+) -> Element {
+    // The reactive view: tasks materialize from IndexedDB on first
+    // client-ready, then auto-update on every local or remote change
+    // via subscribe_resolved. No HashMap, no manual merge.
+    let tasks = use_synced_table::<Task>(client, TASK_TABLE);
+    let mut new_title = use_signal(String::new);
+    let connected = client().is_some();
+    let is_online = online();
+
+    let toggle_online = move |_| {
+        if let Some(l) = link() {
+            let next = !online();
+            l.set_online(next);
+            online.set(next);
+        }
+    };
+
+    let do_add = move || {
+        let title = new_title().trim().to_string();
+        if title.is_empty() {
+            return;
+        }
+        let Some(c) = client() else { return };
+        let task = Task {
+            id: uuid_v4_string(),
+            title,
+            done: false,
+            deleted: false,
+            created_at: now_ms(),
+        };
+        new_title.set(String::new());
+        spawn(async move {
+            let _ = c.submit::<Task>(TASK_TABLE, &task).await;
+        });
+    };
+
+    let toggle_done = move |t: Task| {
+        let Some(c) = client() else { return };
+        let updated = Task { done: !t.done, ..t };
+        spawn(async move {
+            let _ = c.submit::<Task>(TASK_TABLE, &updated).await;
+        });
+    };
+
+    let delete_task = move |t: Task| {
+        let Some(c) = client() else { return };
+        let updated = Task { deleted: true, ..t };
+        spawn(async move {
+            let _ = c.submit::<Task>(TASK_TABLE, &updated).await;
+        });
+    };
+
+    let visible: Vec<Task> = {
+        let mut v: Vec<Task> = tasks().into_iter().filter(|t| !t.deleted).collect();
+        v.sort_by_key(|t| std::cmp::Reverse(t.created_at));
+        v
+    };
+
+    rsx! {
+        div { class: "device-status",
+            span {
+                class: if connected && is_online {
+                    "device-status-dot on"
+                } else if connected && !is_online {
+                    "device-status-dot offline"
+                } else {
+                    "device-status-dot"
+                }
+            }
+            span { style: "flex: 1;",
+                if !connected {
+                    "Starting…"
+                } else if is_online {
+                    "Online"
+                } else {
+                    "Offline"
+                }
+            }
+            if connected {
+                button {
+                    class: "device-toggle",
+                    onclick: toggle_online,
+                    title: if is_online { "Take this device offline" } else { "Bring this device online" },
+                    if is_online { "Go offline" } else { "Go online" }
+                }
+            }
+        }
+        ul { class: "device-tasks",
+            if visible.is_empty() {
+                li { class: "device-empty",
+                    "No tasks yet."
+                }
+            }
+            for t in visible.into_iter() {
+                {
+                    let t_for_toggle = t.clone();
+                    let t_for_delete = t.clone();
+                    let tog = toggle_done;
+                    let del = delete_task;
+                    rsx! {
+                        li {
+                            key: "{t.id}",
+                            class: if t.done { "device-task done" } else { "device-task" },
+                            input {
+                                r#type: "checkbox",
+                                checked: t.done,
+                                onchange: move |_| tog(t_for_toggle.clone()),
+                            }
+                            span { class: "device-task-title", "{t.title}" }
+                            button {
+                                class: "device-task-delete",
+                                onclick: move |_| del(t_for_delete.clone()),
+                                "title": "Delete",
+                                "×"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        div { class: "device-add-row",
+            input {
+                placeholder: "Add a task…",
+                disabled: !connected,
+                value: "{new_title}",
+                oninput: move |e| new_title.set(e.value()),
+                onkeydown: {
+                    let mut do_add = do_add;
+                    move |e| {
+                        if e.key() == Key::Enter {
+                            do_add();
+                        }
+                    }
+                },
+            }
+            button {
+                disabled: !connected,
+                onclick: {
+                    let mut do_add = do_add;
+                    move |_| do_add()
+                },
+                "Add"
+            }
+        }
+        div { class: "device-meta",
+            "store=" code { "{store_name}" }
+        }
+    }
+}
+
+fn uuid_v4_string() -> String {
+    let mut bytes = [0u8; 16];
+    getrandom::getrandom(&mut bytes).expect("crypto.getRandomValues failed");
+    bytes[6] = (bytes[6] & 0x0f) | 0x40;
+    bytes[8] = (bytes[8] & 0x3f) | 0x80;
+    format!(
+        "{:02x}{:02x}{:02x}{:02x}-{:02x}{:02x}-{:02x}{:02x}-{:02x}{:02x}-{:02x}{:02x}{:02x}{:02x}{:02x}{:02x}",
+        bytes[0],
+        bytes[1],
+        bytes[2],
+        bytes[3],
+        bytes[4],
+        bytes[5],
+        bytes[6],
+        bytes[7],
+        bytes[8],
+        bytes[9],
+        bytes[10],
+        bytes[11],
+        bytes[12],
+        bytes[13],
+        bytes[14],
+        bytes[15],
+    )
+}
+
+fn now_ms() -> u64 {
+    js_sys::Date::now() as u64
+}


### PR DESCRIPTION
## Summary

- New `web` feature on `wavesyncdb` adds a wasm32-only `WebSyncClient` that speaks the same snapshot/push protocols as the native engine, persists state in IndexedDB, and exposes the same Dioxus reactive hooks.
- Relay learns `--ws-listen-addr` for browser peers and returns one circuit-relay multiaddr per relay external address per peer so phones (QUIC) and browsers (WS) each see something they can dial.
- New `examples/qr_pairing/` is a single-crate Dioxus app that builds for both web and native; browser renders a pairing QR, phone scans it, both sync through the relay's topic mesh.
- Two correctness fixes that were silently breaking circuit-relay sync (web→peer in particular) — see "Engine fixes" below.

## Engine fixes

**1. `peer_id_from_multiaddr` returns the *last* `/p2p/<id>`, not the first.**
For a circuit-relay multiaddr `/.../p2p/<relay>/p2p-circuit/p2p/<dest>` the first /p2p/ is the relay, the last is the actual destination. Picking the first caused the engine's \"skip relay\" filter to discard every circuit-relay dial from a `PushResponse::PeerList` response — the user-visible symptom is `pushing changeset to 0 peer(s)` even with the relay connected and a peer announced. Fixed on both the wasm side (`web_engine.rs`) and the native side (`engine/mod.rs` + `engine/relay_manager.rs`), where the same bucketing previously dropped circuit dials between two NAT'd natives.

**2. `PeerList` dedup by destination peer-id with WS-circuit preference.**
The relay returns 3+ circuit-relay multiaddrs per peer (one per relay external address). Dialing all of them in parallel made libp2p's `max_established_per_peer = 1` thrash through `connect → ConnectionEstablished → close → reconnect → close` cycles, and the destination's reservation hit `ResourceLimitExceeded` mid-cycle. By the time a write fired, `connected` was empty. Now we pick the highest-scoring single multiaddr per peer (WS-circuit > non-WS-circuit > direct WS > anything else).

## Test plan

- [x] `cargo test -p wavesyncdb --lib` — 147/147
- [x] `cargo test -p wavesyncdb --test integration -- --test-threads=1` — 19/19
- [x] `cargo build -p wavesyncdb --target wasm32-unknown-unknown --features web,dioxus`
- [x] `cargo clippy -p wavesyncdb -p wavesyncdb_derive -p wavesync_relay -- -D warnings`
- [x] `examples/qr_pairing/test.sh --full` — 3 consecutive PASSes, both directions sync within 60s
- [ ] Manual smoke: real browser tab + real phone on the same wifi (the autonomous run uses headless Chrome + the connected adb device)

## How to reproduce the e2e locally

```bash
cd examples/qr_pairing
npm install --save-dev puppeteer-core   # one-time
./test.sh --full                        # rebuilds + reinstalls APK
SKIP_ANDROID_BUILD=1 ./test.sh --full   # APK already on device
./test.sh --stop                        # tear down
```
