### PR TITLE
feat(diagnostics): engine-wide counters foundation (P1.a, #27)

### DIFF
--- a/wavesyncdb/src/connection.rs
+++ b/wavesyncdb/src/connection.rs
@@ -312,6 +312,10 @@ struct WaveSyncDbInner {
     engine_handle: std::sync::Mutex<Option<tokio::task::JoinHandle<()>>>,
     network_status: Arc<std::sync::RwLock<crate::network_status::NetworkStatus>>,
     network_event_tx: broadcast::Sender<crate::network_status::NetworkEvent>,
+    /// Engine-wide diagnostics counters. Shared with the engine task —
+    /// engine writes, [`WaveSyncDb::diagnostics`] reads via lock-free
+    /// atomic loads. See [`crate::diagnostics`] for rationale.
+    diagnostics: Arc<crate::diagnostics::Counters>,
 }
 
 /// A SeaORM connection wrapper that transparently intercepts write operations
@@ -387,6 +391,15 @@ impl WaveSyncDb {
     /// Subscribe to network events (peer connect/disconnect, relay changes, etc.).
     pub fn network_event_rx(&self) -> broadcast::Receiver<crate::network_status::NetworkEvent> {
         self.inner.network_event_tx.subscribe()
+    }
+
+    /// Snapshot the engine's diagnostics counters.
+    ///
+    /// Cheap (a handful of `Relaxed` atomic loads). Counters reset to
+    /// zero on engine restart — see [`crate::diagnostics`] for what each
+    /// counter measures and why this exists.
+    pub fn diagnostics(&self) -> crate::diagnostics::Snapshot {
+        self.inner.diagnostics.snapshot()
     }
 
     /// Get a reference to the sync changeset sender.
@@ -1724,6 +1737,12 @@ impl WaveSyncDbBuilder {
             circuit_max_duration: self.circuit_max_duration,
         };
 
+        // Diagnostics counters are owned jointly by the engine task (writer)
+        // and `WaveSyncDbInner` (reader via `WaveSyncDb::diagnostics`). The
+        // engine clones the Arc, increments through atomic operations, and
+        // never blocks on it.
+        let diagnostics = Arc::new(crate::diagnostics::Counters::default());
+
         // Start the P2P engine in a background task
         let engine_handle = crate::engine::start_engine(
             inner.clone(),
@@ -1738,6 +1757,7 @@ impl WaveSyncDbBuilder {
             self.group_key,
             network_status.clone(),
             network_event_tx.clone(),
+            diagnostics.clone(),
         );
 
         let db = WaveSyncDb {
@@ -1755,6 +1775,7 @@ impl WaveSyncDbBuilder {
                 engine_handle: std::sync::Mutex::new(Some(engine_handle)),
                 network_status,
                 network_event_tx,
+                diagnostics,
             }),
         };
 

--- a/wavesyncdb/src/diagnostics.rs
+++ b/wavesyncdb/src/diagnostics.rs
@@ -1,0 +1,158 @@
+//! Engine-wide diagnostics counters.
+//!
+//! Engine code increments [`Counters`] (via the `Arc<Counters>` shared with
+//! `WaveSyncDbInner`); applications read [`Snapshot`]s via
+//! [`WaveSyncDb::diagnostics`](crate::WaveSyncDb::diagnostics).
+//!
+//! ## Why this exists
+//!
+//! Network-level bug-hunting at the libp2p layer is hard without
+//! quantitative state. Concretely: PR #25 was about a circuit-relay
+//! reservation storm that produced 19+ `ReservationReqAccepted` events
+//! within 1s of pairing, but with no in-engine signal we caught it only
+//! by reading the relay log line by line. With these counters the same
+//! bug becomes a single comparison: `circuit_reservation_attempts`
+//! before vs. after a code change. See [issue #27] for the broader
+//! rationale.
+//!
+//! ## Why atomic counters
+//!
+//! The engine task increments from one thread; UI / debug-panel /
+//! Dioxus-hook readers run on others. Keeping the storage in
+//! [`AtomicU64`] makes a snapshot a sequence of `Relaxed` loads — no
+//! lock acquisition on the hot path — and removes the risk of a slow
+//! reader blocking the engine event loop. The snapshot is a *consistent
+//! enough* view for human/UI consumption (each counter is read
+//! atomically; cross-counter consistency is not guaranteed and not
+//! needed for the use case).
+//!
+//! ## What this is **not**
+//!
+//! * Not a Prometheus / OpenTelemetry exporter — counters live only in
+//!   memory; an exporter is a follow-up if we ever ship a server-mode
+//!   build (see issue #27 non-goals).
+//! * Not retained across engine restarts; the snapshot reflects the
+//!   current process's lifetime.
+//! * Not per-peer; per-peer metrics extend [`crate::network_status::PeerInfo`]
+//!   in the next phase of this work.
+//!
+//! [issue #27]: https://github.com/pvg13/WaveSyncDB/issues/27
+
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use serde::{Deserialize, Serialize};
+
+/// Atomic counters incremented by the engine task. Cloned via `Arc` between
+/// the engine and the owning [`WaveSyncDb`](crate::WaveSyncDb).
+#[derive(Default, Debug)]
+pub(crate) struct Counters {
+    /// `swarm.listen_on(<relay>/p2p-circuit)` calls that the engine
+    /// actually issued (not the ones short-circuited by
+    /// `try_listen_on_circuit`'s idempotency guard from PR #25).
+    pub circuit_reservation_attempts: AtomicU64,
+    /// `relay::client::Event::ReservationReqAccepted` events the engine
+    /// observed, including renewals. Pre-PR-#25 a single pairing emitted
+    /// 19+ of these in a 1s burst — a healthy run shows 1 + the
+    /// proactive-renewal cadence.
+    pub circuit_reservations_accepted: AtomicU64,
+
+    /// `swarm.dial` calls the engine routed through `try_dial_relay`,
+    /// `dial_introduced_peer`, mDNS dial, or rendezvous dial — counts
+    /// *attempts*, not unique peers.
+    pub peer_dial_attempts: AtomicU64,
+    /// `SwarmEvent::ConnectionEstablished` events for non-infrastructure
+    /// peers. The ratio of `peer_dial_successes / peer_dial_attempts` is
+    /// the per-engine dial-success rate (under 50% on most NAT pairs is
+    /// expected and acceptable; under 5% indicates a real problem).
+    pub peer_dial_successes: AtomicU64,
+    /// `SwarmEvent::OutgoingConnectionError` for non-infrastructure peers.
+    /// Most of these are routine (transport not supported, peer behind
+    /// symmetric NAT); a sustained spike is a discovery-layer bug.
+    pub peer_dial_failures: AtomicU64,
+
+    /// Distinct peer-id discoveries via the mDNS `Discovered` event.
+    /// Counts peer-id arrivals, not address arrivals — multiple addresses
+    /// for the same peer in one mDNS query increment this once.
+    pub mdns_discoveries: AtomicU64,
+    /// Peer introductions returned by the relay in a `PushResponse::PeerList`
+    /// (i.e. peers that were on the topic when *we* announced presence).
+    /// Pre-introduction-dedup the same peer could be counted N times per
+    /// announce cycle if it had N addresses; post-fix this counts unique
+    /// peer-ids.
+    pub peerlist_introductions: AtomicU64,
+    /// Peer introductions delivered via `PushRequest::PeerJoined`
+    /// (i.e. someone joined the topic *after* we announced).
+    pub peerjoined_introductions: AtomicU64,
+}
+
+impl Counters {
+    /// Read every counter into a [`Snapshot`]. `Relaxed` ordering: each
+    /// counter is read atomically but cross-counter consistency is not
+    /// guaranteed (and not needed for human/UI consumption).
+    pub(crate) fn snapshot(&self) -> Snapshot {
+        Snapshot {
+            circuit_reservation_attempts: self.circuit_reservation_attempts.load(Ordering::Relaxed),
+            circuit_reservations_accepted: self
+                .circuit_reservations_accepted
+                .load(Ordering::Relaxed),
+            peer_dial_attempts: self.peer_dial_attempts.load(Ordering::Relaxed),
+            peer_dial_successes: self.peer_dial_successes.load(Ordering::Relaxed),
+            peer_dial_failures: self.peer_dial_failures.load(Ordering::Relaxed),
+            mdns_discoveries: self.mdns_discoveries.load(Ordering::Relaxed),
+            peerlist_introductions: self.peerlist_introductions.load(Ordering::Relaxed),
+            peerjoined_introductions: self.peerjoined_introductions.load(Ordering::Relaxed),
+        }
+    }
+}
+
+/// Read-only snapshot of the engine's diagnostics counters.
+///
+/// Obtained via [`WaveSyncDb::diagnostics`](crate::WaveSyncDb::diagnostics).
+/// Each field is a monotonically-increasing count over the engine's
+/// lifetime — to derive a rate, sample twice and divide by elapsed time.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct Snapshot {
+    pub circuit_reservation_attempts: u64,
+    pub circuit_reservations_accepted: u64,
+    pub peer_dial_attempts: u64,
+    pub peer_dial_successes: u64,
+    pub peer_dial_failures: u64,
+    pub mdns_discoveries: u64,
+    pub peerlist_introductions: u64,
+    pub peerjoined_introductions: u64,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+
+    #[test]
+    fn snapshot_returns_zero_for_fresh_counters() {
+        let c = Counters::default();
+        assert_eq!(c.snapshot(), Snapshot::default());
+    }
+
+    #[test]
+    fn snapshot_observes_increments_across_threads() {
+        let c = Arc::new(Counters::default());
+        let mut handles = Vec::new();
+        for _ in 0..4 {
+            let c = Arc::clone(&c);
+            handles.push(std::thread::spawn(move || {
+                for _ in 0..1_000 {
+                    c.peer_dial_attempts.fetch_add(1, Ordering::Relaxed);
+                    c.peer_dial_successes.fetch_add(1, Ordering::Relaxed);
+                }
+            }));
+        }
+        for h in handles {
+            h.join().unwrap();
+        }
+        let snap = c.snapshot();
+        assert_eq!(snap.peer_dial_attempts, 4_000);
+        assert_eq!(snap.peer_dial_successes, 4_000);
+        // Untouched counters stay zero.
+        assert_eq!(snap.mdns_discoveries, 0);
+    }
+}

--- a/wavesyncdb/src/engine/mod.rs
+++ b/wavesyncdb/src/engine/mod.rs
@@ -129,7 +129,7 @@ impl EngineConfig {
 
 /// Start the P2P sync engine in a background tokio task.
 #[allow(clippy::too_many_arguments)]
-pub fn start_engine(
+pub(crate) fn start_engine(
     db: DatabaseConnection,
     sync_rx: mpsc::Receiver<SyncChangeset>,
     change_tx: broadcast::Sender<ChangeNotification>,
@@ -142,6 +142,7 @@ pub fn start_engine(
     group_key: Option<GroupKey>,
     network_status: Arc<std::sync::RwLock<crate::network_status::NetworkStatus>>,
     network_event_tx: broadcast::Sender<crate::network_status::NetworkEvent>,
+    diagnostics: Arc<crate::diagnostics::Counters>,
 ) -> tokio::task::JoinHandle<()> {
     tokio::spawn(async move {
         let event_tx = network_event_tx.clone();
@@ -158,6 +159,7 @@ pub fn start_engine(
             group_key,
             network_status,
             network_event_tx,
+            diagnostics,
         ))
         .catch_unwind()
         .await;
@@ -266,6 +268,7 @@ async fn run_engine(
     group_key: Option<GroupKey>,
     network_status: Arc<std::sync::RwLock<crate::network_status::NetworkStatus>>,
     network_event_tx: broadcast::Sender<crate::network_status::NetworkEvent>,
+    diagnostics: Arc<crate::diagnostics::Counters>,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     // Load (or create on first launch) the persistent libp2p keypair from
     // _wavesync_meta. Stable PeerId across restarts is necessary so the
@@ -361,6 +364,7 @@ async fn run_engine(
         circuit_retry_count: 0,
         circuit_listen_pending: false,
         relay_dial_pending: false,
+        diagnostics,
     };
 
     // Set initial network status with local_peer_id and topic
@@ -487,6 +491,11 @@ struct EngineRunner {
     /// 3 reservation requests). Cleared on the connection-established or
     /// dial-failed event for the relay peer.
     pub(crate) relay_dial_pending: bool,
+    /// Engine-wide diagnostics counters, shared with `WaveSyncDbInner`.
+    /// All increments are `Relaxed` atomic ops on the hot path; readers
+    /// (UI / debug panel / test assertions) snapshot via
+    /// [`WaveSyncDb::diagnostics`]. See [`crate::diagnostics`].
+    pub(crate) diagnostics: Arc<crate::diagnostics::Counters>,
 }
 
 impl EngineRunner {
@@ -579,6 +588,9 @@ impl EngineRunner {
         match self.swarm.listen_on(circuit_addr.clone()) {
             Ok(_) => {
                 self.circuit_listen_pending = true;
+                self.diagnostics
+                    .circuit_reservation_attempts
+                    .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
                 log::info!(
                     "Listening on relay circuit ({}): {circuit_addr}",
                     if force_renewal { "renewal" } else { "initial" }
@@ -1242,6 +1254,14 @@ impl EngineRunner {
                 peer_id, endpoint, ..
             } => {
                 log::info!("Connection established with {peer_id}");
+                // Count successful peer dials. Infrastructure peers (relay /
+                // rendezvous) are excluded so the rate reflects sync-peer
+                // discovery health, not infra plumbing.
+                if !self.infrastructure_peers.contains(&peer_id) {
+                    self.diagnostics
+                        .peer_dial_successes
+                        .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                }
                 self.handle_connection_established(peer_id, &endpoint).await;
             }
             SwarmEvent::ConnectionClosed {
@@ -1302,6 +1322,16 @@ impl EngineRunner {
                     && pid == relay_pid
                 {
                     self.relay_dial_pending = false;
+                }
+                // Count peer dial failures, excluding infrastructure peers so
+                // the metric reflects sync-peer reachability — failed relay
+                // redials are a separate (and noisier) signal.
+                if let Some(pid) = peer_id
+                    && !self.infrastructure_peers.contains(&pid)
+                {
+                    self.diagnostics
+                        .peer_dial_failures
+                        .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
                 }
                 if let Some(pid) = peer_id {
                     self.dialing_peers.remove(&pid);
@@ -1377,6 +1407,9 @@ impl EngineRunner {
                         "Relay {peer} introduced {} peer(s) on our topic",
                         by_peer.len()
                     );
+                    self.diagnostics
+                        .peerlist_introductions
+                        .fetch_add(by_peer.len() as u64, std::sync::atomic::Ordering::Relaxed);
                     for (_pid, addrs) in by_peer {
                         self.dial_introduced_peer(&addrs);
                     }
@@ -1425,6 +1458,9 @@ impl EngineRunner {
                             "Relay announced new peer on topic with {} address(es)",
                             peer_addrs.len()
                         );
+                        self.diagnostics
+                            .peerjoined_introductions
+                            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
                         // peer_addrs is already a single peer's address set —
                         // pass them all to the dialer so libp2p races them.
                         self.dial_introduced_peer(peer_addrs);

--- a/wavesyncdb/src/engine/peer_manager.rs
+++ b/wavesyncdb/src/engine/peer_manager.rs
@@ -67,7 +67,16 @@ impl EngineRunner {
     pub(super) fn handle_mdns(&mut self, event: mdns::Event) {
         match event {
             mdns::Event::Discovered(list) => {
+                // mDNS often produces multiple addresses for the same peer-id
+                // in one event (each network interface that responded). Count
+                // each *peer* once, not each address.
+                let mut counted_peers = std::collections::HashSet::new();
                 for (peer_id, multiaddr) in list {
+                    if counted_peers.insert(peer_id) {
+                        self.diagnostics
+                            .mdns_discoveries
+                            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                    }
                     // Never re-add peers rejected for topic mismatch
                     if self.rejected_peers.contains(&peer_id) {
                         continue;
@@ -85,10 +94,17 @@ impl EngineRunner {
                     // Dial if not currently connected (handles both new peers and reconnections
                     // after network disruption where the peer is still in self.peers but the
                     // TCP/QUIC connection is dead)
-                    if !self.swarm.is_connected(&peer_id)
-                        && let Err(e) = self.swarm.dial(multiaddr.clone())
-                    {
-                        log::warn!("Failed to dial peer {peer_id}: {e}");
+                    if !self.swarm.is_connected(&peer_id) {
+                        match self.swarm.dial(multiaddr.clone()) {
+                            Ok(()) => {
+                                self.diagnostics
+                                    .peer_dial_attempts
+                                    .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                            }
+                            Err(e) => {
+                                log::warn!("Failed to dial peer {peer_id}: {e}");
+                            }
+                        }
                     }
                     self.peers.insert(peer_id, multiaddr.clone());
 

--- a/wavesyncdb/src/engine/relay_manager.rs
+++ b/wavesyncdb/src/engine/relay_manager.rs
@@ -14,6 +14,9 @@ impl EngineRunner {
                 self.relay_state = RelayState::Listening { relay_peer_id };
                 self.circuit_retry_count = 0;
                 self.circuit_accepted_at = Some(tokio::time::Instant::now());
+                self.diagnostics
+                    .circuit_reservations_accepted
+                    .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
                 // Clear the in-flight flag — the relay accepted our request,
                 // so the next legitimate caller (proactive renewal,
                 // listener-closed re-listen) can issue a fresh one without
@@ -452,6 +455,9 @@ impl EngineRunner {
             .build();
         match self.swarm.dial(dial_opts) {
             Ok(()) => {
+                self.diagnostics
+                    .peer_dial_attempts
+                    .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
                 self.dialing_peers.insert(peer_id);
                 if let Some(first) = addrs.into_iter().next() {
                     self.peers.entry(peer_id).or_insert(first);

--- a/wavesyncdb/src/lib.rs
+++ b/wavesyncdb/src/lib.rs
@@ -41,6 +41,7 @@
 // shared with browser builds.
 pub mod auth;
 pub mod conflict;
+pub mod diagnostics;
 pub mod messages;
 pub mod network_status;
 pub mod protocol;

--- a/wavesyncdb/tests/diagnostics.rs
+++ b/wavesyncdb/tests/diagnostics.rs
@@ -1,0 +1,80 @@
+//! Engine-diagnostics integration tests.
+//!
+//! Validates that the counters surfaced through
+//! [`wavesyncdb::WaveSyncDb::diagnostics`] actually move during a
+//! real two-peer scenario. The point isn't to assert exact values
+//! (timing-sensitive on CI runners) — it's to catch silent regressions
+//! where a future refactor accidentally bypasses the increment site.
+//!
+//! Single-threaded per CLAUDE.md Rule 2.13: mDNS discovery is process-wide
+//! and parallel tests cross-discover.
+//!
+//! Run with `cargo test -p wavesyncdb --test diagnostics -- --test-threads=1`.
+
+mod common;
+
+use std::time::Duration;
+use uuid::Uuid;
+
+use common::{assert_eventually, make_peer, mem_db};
+
+#[tokio::test]
+async fn test_diagnostics_counters_fire_during_two_peer_sync() {
+    let _ = env_logger::try_init();
+    let topic = format!("test-diag-{}", Uuid::new_v4());
+    let timeout = Duration::from_secs(15);
+
+    // Both peers fresh; mDNS will discover them on the local interface.
+    let alice = make_peer(&mem_db("diag_alice"), &topic, 240).await;
+    let bob = make_peer(&mem_db("diag_bob"), &topic, 241).await;
+
+    // Both engines come up with all counters at zero.
+    let initial = alice.diagnostics();
+    assert_eq!(initial.mdns_discoveries, 0);
+    assert_eq!(initial.peer_dial_attempts, 0);
+    assert_eq!(initial.peer_dial_successes, 0);
+
+    // Wait until both sides have seen each other end-to-end. The earliest
+    // signal is mDNS discovery; success happens after the dial completes.
+    assert_eventually(
+        "alice sees bob via mDNS + dials successfully",
+        timeout,
+        || async {
+            let s = alice.diagnostics();
+            s.mdns_discoveries >= 1 && s.peer_dial_successes >= 1
+        },
+    )
+    .await;
+
+    let alice_after = alice.diagnostics();
+    let bob_after = bob.diagnostics();
+
+    // Sanity: mDNS produced at least one peer-id arrival on Alice (the
+    // helper dedups by peer-id within a single Discovered event, so this
+    // counts unique peers, not addresses).
+    assert!(
+        alice_after.mdns_discoveries >= 1,
+        "alice mdns_discoveries = {}",
+        alice_after.mdns_discoveries
+    );
+
+    // Sanity: at least one of {Alice, Bob} dialed the other successfully.
+    // libp2p races both sides; whichever wins gets the success on its
+    // counter and the other observes a ConnectionEstablished as the
+    // *listener*. So we OR the two counts rather than asserting both.
+    assert!(
+        alice_after.peer_dial_successes + bob_after.peer_dial_successes >= 1,
+        "no successful peer dial counted: alice={} bob={}",
+        alice_after.peer_dial_successes,
+        bob_after.peer_dial_successes
+    );
+
+    // Sanity: at least one dial attempt was actually made — guards
+    // against the increment getting deleted in a future refactor.
+    assert!(
+        alice_after.peer_dial_attempts + bob_after.peer_dial_attempts >= 1,
+        "no peer dial attempt counted: alice={} bob={}",
+        alice_after.peer_dial_attempts,
+        bob_after.peer_dial_attempts
+    );
+}


### PR DESCRIPTION
First slice of the network-stability roadmap (#27). **Diagnose-first**: before fixing anything else, give the engine a quantitative voice.

## What this lands

A new `wavesyncdb::diagnostics` module exposing engine-wide counters via `WaveSyncDb::diagnostics() -> Snapshot`. Reads are lock-free atomic loads — safe to call from UI / Dioxus hooks. The engine task increments at the canonical event sites:

| Counter | Wired at |
|---|---|
| `circuit_reservation_attempts` | `try_listen_on_circuit` after the actual `swarm.listen_on` (skips the #25 idempotency-guard no-ops) |
| `circuit_reservations_accepted` | `handle_relay_client::ReservationReqAccepted` (includes renewals) |
| `peer_dial_attempts` | `dial_introduced_peer` (PeerList + PeerJoined) and the mDNS dial site |
| `peer_dial_successes` / `peer_dial_failures` | `SwarmEvent::ConnectionEstablished` / `OutgoingConnectionError`, infra peers excluded |
| `mdns_discoveries` | unique peer-ids per mDNS `Discovered` event (multi-address replies for one peer count once) |
| `peerlist_introductions` / `peerjoined_introductions` | distinct peer-ids announced by the relay's topic mesh |

## Why this comes first

PR #25 is the smoking gun. We shipped against the renewal-storm signature for months by reading `relay.log` line-by-line; with these counters the same diagnosis is `before.circuit_reservation_attempts vs after.circuit_reservation_attempts` — automatic, not bespoke. Every later phase (P2 connection FSM, P3 backpressure, P4 discovery layering, P5 chaos tests) needs this.

## Out of scope (sub-tasks of #27)

- Per-peer metrics on `network_status::PeerInfo` — connection age, last inbound/outbound, RTT, bytes
- Sync-latency histogram (write → remote `apply_remote_changeset`)
- Relay-side counters in `wavesync_relay`
- HDR-style histogram fields — counters only for now
- qr-pairing debug-panel wiring — UI commit
- Prometheus / OpenTelemetry exporter — explicit non-goal in #27

## Test plan

- [x] 2 new unit tests in the diagnostics module: zero-init snapshot + cross-thread atomic increment convergence (4×1_000 → 4_000 with untouched counters at 0).
- [x] New `tests/diagnostics.rs` integration: brings up two peers, waits for mDNS + a successful dial, asserts the three relevant counters moved off zero. Tolerant of dial-race winner so it isn't flaky.
- [x] `cargo test -p wavesyncdb --lib` — 153/153 (151 + 2 new)
- [x] `cargo test -p wavesyncdb --test integration -- --test-threads=1` — 19/19
- [x] `cargo test -p wavesyncdb --test integration_sync -- --test-threads=1` — 18/18
- [x] Multi-row INSERT regression tests from #26 still pass — 2/2
- [x] `cargo build -p wavesyncdb --target wasm32-unknown-unknown --features web,dioxus`
- [x] `cargo clippy -p wavesyncdb -p wavesyncdb_derive -p wavesync_relay -- -D warnings`
- [x] `rustfmt --check`

### Side effect worth flagging

`start_engine` is now `pub(crate)`. It was previously `pub` but only ever called from `connection.rs::WaveSyncDbBuilder::build` in the same crate; the visibility was a leak that became a clippy `private-interfaces` error once the new internal `Arc<Counters>` parameter was added. No external API surface change since nothing outside the crate referenced it.

Refs #27.
