### PR TITLE
feat(wasm): one-source-of-truth entities + cross-target use_synced_table

### DIFF
--- a/examples/dioxus_app/src/main.rs
+++ b/examples/dioxus_app/src/main.rs
@@ -5,7 +5,7 @@ use std::sync::OnceLock;
 use entity::task;
 use sea_orm::{ActiveModelTrait, EntityTrait, Set};
 use uuid::Uuid;
-use wavesyncdb::dioxus::{use_synced_table, use_wavesync, use_wavesync_provider};
+use wavesyncdb::dioxus::{SyncHandle, use_synced_table, use_wavesync, use_wavesync_provider};
 use wavesyncdb::{WaveSyncDb, WaveSyncDbBuilder};
 
 use dioxus::prelude::*;
@@ -110,7 +110,7 @@ fn AddTaskForm() -> Element {
 #[component]
 fn TaskList() -> Element {
     let db = use_wavesync();
-    let tasks = use_synced_table::<task::Entity>(db);
+    let tasks = use_synced_table::<task::Model>(SyncHandle::new(db));
 
     rsx! {
         ul { class: "task-list",

--- a/examples/dioxus_dynamic/src/main.rs
+++ b/examples/dioxus_dynamic/src/main.rs
@@ -4,7 +4,7 @@ use entity::task;
 use sea_orm::{ActiveModelTrait, EntityTrait, Set};
 use uuid::Uuid;
 use wavesyncdb::dioxus::{
-    use_synced_table, use_wavesync_init, use_wavesync_opt, use_wavesync_provider_lazy,
+    SyncHandle, use_synced_table, use_wavesync_init, use_wavesync_opt, use_wavesync_provider_lazy,
 };
 
 use dioxus::prelude::*;
@@ -165,7 +165,7 @@ fn AddTaskForm() -> Element {
 #[component]
 fn TaskList() -> Element {
     let db = use_wavesync_opt()().unwrap();
-    let tasks = use_synced_table::<task::Entity>(db);
+    let tasks = use_synced_table::<task::Model>(SyncHandle::new(db));
 
     rsx! {
         ul { class: "task-list",

--- a/examples/dioxus_fcm_sync/src/main.rs
+++ b/examples/dioxus_fcm_sync/src/main.rs
@@ -52,7 +52,8 @@ use entity::task;
 use sea_orm::{ActiveModelTrait, EntityTrait, Set};
 use uuid::Uuid;
 use wavesyncdb::dioxus::{
-    use_auto_lifecycle, use_network_status, use_synced_table, use_wavesync, use_wavesync_provider,
+    SyncHandle, use_auto_lifecycle, use_network_status, use_synced_table, use_wavesync,
+    use_wavesync_provider,
 };
 use wavesyncdb::{WaveSyncDb, WaveSyncDbBuilder};
 
@@ -355,7 +356,7 @@ fn AddTaskForm() -> Element {
 #[component]
 fn TaskList() -> Element {
     let db = use_wavesync();
-    let tasks = use_synced_table::<task::Entity>(db);
+    let tasks = use_synced_table::<task::Model>(SyncHandle::new(db));
 
     rsx! {
         ul { class: "task-list",

--- a/examples/qr_pairing/Cargo.toml
+++ b/examples/qr_pairing/Cargo.toml
@@ -39,8 +39,9 @@ dioxus-sdk-storage = { git = "https://github.com/DioxusLabs/sdk.git" }
 android_logger = "0.14"
 
 # Wasm32 (browser): WebSyncClient + IndexedDB + QR generator. No
-# SeaORM, no sqlx — those don't compile to wasm32. The example's web
-# task entity is a plain struct that `impl BrowserEntity` instead.
+# SeaORM, no sqlx — those don't compile to wasm32. The task entity is
+# a plain struct deriving `SyncEntity`; the derive emits an
+# `impl BrowserEntity` for wasm targets (and SeaORM glue on native).
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wavesyncdb = { workspace = true, features = ["web", "dioxus"] }
 # QR generator. Default `image` feature would pull in PNG encoding

--- a/examples/qr_pairing/src/native_app.rs
+++ b/examples/qr_pairing/src/native_app.rs
@@ -26,7 +26,7 @@ use dioxus::prelude::*;
 use sea_orm::{ActiveModelTrait, Set};
 use uuid::Uuid;
 use wavesyncdb::dioxus::{
-    use_network_status, use_synced_table, use_wavesync, use_wavesync_provider,
+    SyncHandle, use_network_status, use_synced_table, use_wavesync, use_wavesync_provider,
 };
 use wavesyncdb::{NatStatus, RelayStatus, WaveSyncDb, WaveSyncDbBuilder};
 
@@ -611,9 +611,10 @@ fn AddTaskForm() -> Element {
 #[component]
 fn TaskList() -> Element {
     let db = use_wavesync();
-    // `use_synced_table` consumes the db value; clone first so we can
-    // still hand it to the per-task toggle handlers below.
-    let tasks = use_synced_table::<task::Entity>(db.clone());
+    // `SyncHandle` consumes the db value; clone first so we can still
+    // hand it to the per-task toggle handlers below (those use the
+    // db directly via SeaORM ActiveModel — native-only escape hatch).
+    let tasks = use_synced_table::<task::Model>(SyncHandle::new(db.clone()));
 
     let mut visible: Vec<task::Model> = tasks().clone();
     visible.sort_by_key(|t| std::cmp::Reverse(t.created_at));

--- a/examples/qr_pairing/src/web_app.rs
+++ b/examples/qr_pairing/src/web_app.rs
@@ -10,11 +10,13 @@
 //! discover each other through the relay's topic mesh.
 
 use dioxus::prelude::*;
-use wavesyncdb::{SyncEntity, WebSyncClient, WebSyncStatus, dioxus::use_synced_table};
+use wavesyncdb::{
+    SyncEntity, WebSyncClient, WebSyncStatus,
+    dioxus::{SyncHandle, use_synced_table},
+};
 
 use crate::pairing::{PairingParams, build_pairing_url};
 
-const TASK_TABLE: &str = "tasks";
 const STORE_NAME: &str = "qr-pairing-web";
 
 /// PeerId of the default relay (the one the README's
@@ -39,6 +41,7 @@ const DEFAULT_TOPIC: &str = "qr-pairing-demo";
 const DEFAULT_PASS: &str = "demo-shared-secret";
 
 #[derive(Clone, Debug, Default, SyncEntity)]
+#[sea_orm(table_name = "tasks")]
 struct Task {
     #[sea_orm(primary_key)]
     id: String,
@@ -108,7 +111,7 @@ pub fn App() -> Element {
             if client().is_some() {
                 PairingPanel { client: client, topic: topic(), pass: pass() }
                 DebugPanel { client: client }
-                TaskList { client: client }
+                TaskList { handle: SyncHandle::new(client) }
             } else {
                 div { class: "panel",
                     h2 { "Pair a phone" }
@@ -178,8 +181,8 @@ fn PairingPanel(client: Signal<Option<WebSyncClient>>, topic: String, pass: Stri
 }
 
 #[component]
-fn TaskList(client: Signal<Option<WebSyncClient>>) -> Element {
-    let tasks = use_synced_table::<Task>(client, TASK_TABLE);
+fn TaskList(handle: SyncHandle) -> Element {
+    let tasks = use_synced_table::<Task>(handle);
     let mut new_title = use_signal(String::new);
 
     let do_add = use_callback(move |_: ()| {
@@ -187,7 +190,6 @@ fn TaskList(client: Signal<Option<WebSyncClient>>) -> Element {
         if title.is_empty() {
             return;
         }
-        let Some(c) = client() else { return };
         let task = Task {
             id: uuid_v4_string(),
             title,
@@ -196,15 +198,14 @@ fn TaskList(client: Signal<Option<WebSyncClient>>) -> Element {
         };
         new_title.set(String::new());
         spawn(async move {
-            let _ = c.submit::<Task>(TASK_TABLE, &task).await;
+            let _ = handle.submit(&task).await;
         });
     });
 
     let toggle = move |t: Task| {
-        let Some(c) = client() else { return };
         let updated = Task { done: !t.done, ..t };
         spawn(async move {
-            let _ = c.submit::<Task>(TASK_TABLE, &updated).await;
+            let _ = handle.submit(&updated).await;
         });
     };
 

--- a/examples/qr_pairing/src/web_app.rs
+++ b/examples/qr_pairing/src/web_app.rs
@@ -9,12 +9,8 @@
 //! the same topic via *its* hardcoded relay, and the two peers
 //! discover each other through the relay's topic mesh.
 
-use std::collections::HashMap;
-
 use dioxus::prelude::*;
-use wavesyncdb::{
-    BrowserEntity, WebSyncClient, WebSyncStatus, dioxus::use_synced_table, serde_json,
-};
+use wavesyncdb::{SyncEntity, WebSyncClient, WebSyncStatus, dioxus::use_synced_table};
 
 use crate::pairing::{PairingParams, build_pairing_url};
 
@@ -42,45 +38,13 @@ fn relay_addr() -> String {
 const DEFAULT_TOPIC: &str = "qr-pairing-demo";
 const DEFAULT_PASS: &str = "demo-shared-secret";
 
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, SyncEntity)]
 struct Task {
+    #[sea_orm(primary_key)]
     id: String,
     title: String,
     done: bool,
     created_at: u64,
-}
-
-impl BrowserEntity for Task {
-    fn from_columns(pk: &str, cols: &HashMap<String, serde_json::Value>) -> Self {
-        Task {
-            id: pk.to_string(),
-            title: cols
-                .get("title")
-                .and_then(|v| v.as_str())
-                .unwrap_or("(untitled)")
-                .to_string(),
-            done: cols.get("done").and_then(|v| v.as_bool()).unwrap_or(false),
-            created_at: cols.get("created_at").and_then(|v| v.as_u64()).unwrap_or(0),
-        }
-    }
-
-    fn to_columns(&self) -> Vec<(String, serde_json::Value)> {
-        vec![
-            (
-                "title".to_string(),
-                serde_json::Value::String(self.title.clone()),
-            ),
-            ("done".to_string(), serde_json::Value::Bool(self.done)),
-            (
-                "created_at".to_string(),
-                serde_json::Value::Number(serde_json::Number::from(self.created_at)),
-            ),
-        ]
-    }
-
-    fn pk(&self) -> String {
-        self.id.clone()
-    }
 }
 
 #[component]

--- a/wavesyncdb/Cargo.toml
+++ b/wavesyncdb/Cargo.toml
@@ -106,5 +106,6 @@ mobile-ffi = []
 # shadow tables, peer tracker, push helpers, and FFI surface are
 # `cfg(not(target_arch = "wasm32"))`-gated and unavailable in browser builds.
 # Browser-side P2P transports (WebSocket / WebRTC / WebTransport) are a
-# separate, future opt-in.
-web = []
+# separate, future opt-in. Pulls in `derive` so `#[derive(SyncEntity)]`
+# auto-generates `impl BrowserEntity` on wasm.
+web = ["derive"]

--- a/wavesyncdb/src/dioxus/hooks.rs
+++ b/wavesyncdb/src/dioxus/hooks.rs
@@ -275,7 +275,14 @@ pub fn use_peer_identities(
 // Reactive table/row hooks
 // ---------------------------------------------------------------------------
 
-/// Reactive signal containing all rows in a table.
+/// Reactive signal containing all rows in a table, keyed by a SeaORM
+/// `Entity` type and operating directly on a [`WaveSyncDb`].
+///
+/// **Most apps should use [`super::use_synced_table`] instead** — the
+/// cross-target hook that takes a [`SyncHandle`](super::SyncHandle) and
+/// works identically on native and wasm32. This `_db` variant is the
+/// native-only escape hatch for code that holds a `WaveSyncDb` directly
+/// (e.g., legacy callers, advanced query setups).
 ///
 /// Performs an initial `E::find().all(db)` query, then keeps the in-memory
 /// `Vec<E::Model>` in sync with subsequent writes by **applying the
@@ -287,7 +294,7 @@ pub fn use_peer_identities(
 /// Falls back to a full `find().all()` reload only when the broadcast
 /// channel reports `Lagged` — i.e. the subscriber missed notifications and
 /// can't reconstruct the delta.
-pub fn use_synced_table<E>(db: WaveSyncDb) -> Signal<Vec<E::Model>>
+pub fn use_synced_table_db<E>(db: WaveSyncDb) -> Signal<Vec<E::Model>>
 where
     E: EntityTrait,
     E::Model: FromQueryResult + SyncedModel + Clone + Send + Sync + 'static,

--- a/wavesyncdb/src/dioxus/mod.rs
+++ b/wavesyncdb/src/dioxus/mod.rs
@@ -7,8 +7,15 @@
 //! - [`use_wavesync()`] — retrieve the `&'static WaveSyncDb` from context.
 //! - [`use_wavesync_opt()`] — returns `Signal<Option<&'static WaveSyncDb>>`.
 //! - [`use_wavesync_init()`] — returns an [`InitDb`] handle to build the DB at runtime.
-//! - [`use_synced_table`] — reactive signal of all rows in a table, auto-refreshes on writes.
+//! - [`use_synced_table`] — cross-target reactive signal of all rows
+//!   in a table. Takes a [`SyncHandle`] so the same UI component
+//!   compiles on native and wasm32 without cfg gating at the call site.
+//! - [`use_synced_table_db`] / [`use_synced_table_client`] — backend-
+//!   specific escape hatches when a [`SyncHandle`] isn't available.
 //! - [`use_synced_row`] — reactive signal for a single row by primary key.
+//! - [`SyncHandle`] — opaque transport wrapper (`WaveSyncDb` on native,
+//!   `Signal<Option<WebSyncClient>>` on wasm32) with a unified
+//!   [`SyncHandle::submit`] for writes.
 //!
 //! ## Example
 //!
@@ -20,20 +27,17 @@
 //!         .unwrap();
 //!     let _guard = rt.enter();
 //!
-//!     let db: &'static WaveSyncDb = rt.block_on(async {
+//!     let db: WaveSyncDb = rt.block_on(async {
 //!         let db = WaveSyncDbBuilder::new("sqlite:./app.db?mode=rwc", "my-topic")
 //!             .build().await.unwrap();
-//!         let db = Box::leak(Box::new(db));
 //!         db.get_schema_registry(module_path!().split("::").next().unwrap())
 //!             .sync().await.unwrap();
 //!         db
 //!     });
 //!
 //!     dioxus::launch(move || {
-//!         wavesyncdb::dioxus::use_wavesync_provider(db);
-//!         let tasks = wavesyncdb::dioxus::use_synced_table::<task::Entity>(
-//!             wavesyncdb::dioxus::use_wavesync()
-//!         );
+//!         let handle = wavesyncdb::dioxus::SyncHandle::new(db.clone());
+//!         let tasks = wavesyncdb::dioxus::use_synced_table::<task::Model>(handle);
 //!         // ... render tasks
 //!         todo!()
 //!     });
@@ -56,3 +60,10 @@ pub use hooks::*;
 pub mod web_hooks;
 #[cfg(target_arch = "wasm32")]
 pub use web_hooks::*;
+
+// Cross-target transport facade. Exposes [`SyncHandle`], the
+// target-agnostic [`use_synced_table`] hook, and [`SyncSubmitError`].
+// Lives outside `hooks` / `web_hooks` so the same definitions are
+// available on both targets.
+pub mod sync_handle;
+pub use sync_handle::{SyncHandle, SyncSubmitError, use_synced_table};

--- a/wavesyncdb/src/dioxus/sync_handle.rs
+++ b/wavesyncdb/src/dioxus/sync_handle.rs
@@ -1,0 +1,220 @@
+//! Cross-target transport handle for shared Dioxus UI components.
+//!
+//! The native and web sync backends have fundamentally different runtime
+//! shapes — [`WaveSyncDb`] (SeaORM connection pool) on native vs
+//! [`WebSyncClient`] (libp2p over WebSocket) on wasm32 — so the hooks
+//! that read and write to them can't share a transport parameter
+//! verbatim. `SyncHandle` is the thin facade that hides this: a
+//! target-specific opaque wrapper with a constructor, a clone-friendly
+//! shape, and an async [`submit`](Self::submit) method that dispatches
+//! to whichever backend is compiled in.
+//!
+//! UI components written against `SyncHandle` compile unchanged on both
+//! targets — `use_synced_table::<E>(handle)` reads uniformly,
+//! `handle.submit(&entity).await` writes uniformly. Apps construct the
+//! handle at the entry point (one cfg-gated arm per target) and pass
+//! it down as a component prop or context value.
+//!
+//! [`WaveSyncDb`]: crate::WaveSyncDb
+//! [`WebSyncClient`]: crate::WebSyncClient
+
+use dioxus::prelude::*;
+
+use crate::synced_table::SyncedTableEntity;
+
+#[cfg(not(target_arch = "wasm32"))]
+use crate::WaveSyncDb;
+#[cfg(target_arch = "wasm32")]
+use crate::WebSyncClient;
+
+/// Target-specific transport wrapper. Construct with `SyncHandle::new`
+/// passing whichever backend is compiled in.
+///
+/// The handle is always cheap to clone — native stores a `WaveSyncDb`
+/// (itself an `Arc`-shaped clone), web stores a Dioxus `Signal` (a
+/// `Copy`-shaped reactive handle). On wasm, `SyncHandle` is `Copy` as
+/// well so it can be freely captured in Dioxus event-handler closures
+/// without per-call cloning. On native it's `Clone` only because
+/// `WaveSyncDb` carries non-`Copy` state; shared UI components that
+/// target both should still call `handle.clone()` defensively to keep
+/// the source identical across targets.
+#[derive(Clone)]
+#[cfg_attr(target_arch = "wasm32", derive(Copy))]
+pub struct SyncHandle {
+    #[cfg(not(target_arch = "wasm32"))]
+    pub(crate) db: WaveSyncDb,
+    #[cfg(target_arch = "wasm32")]
+    pub(crate) client: Signal<Option<WebSyncClient>>,
+}
+
+/// Always equal. Dioxus's `#[component]` macro derives a prop-equality
+/// check to decide whether to skip re-renders on parent updates;
+/// `SyncHandle` is conceptually a singleton for a component's lifetime
+/// (the same backend connection from mount to unmount) so comparing
+/// two instances meaningfully would require dereferencing the
+/// underlying `Arc` / `Signal`, and the answer would be "the same one
+/// you saw before" anyway. Internal reactivity (the hook's own
+/// subscription to `change_rx` / `subscribe_resolved`) drives renders
+/// on data changes, not prop equality.
+impl PartialEq for SyncHandle {
+    fn eq(&self, _other: &Self) -> bool {
+        true
+    }
+}
+
+impl SyncHandle {
+    /// Wrap a native [`WaveSyncDb`].
+    #[cfg(not(target_arch = "wasm32"))]
+    pub fn new(db: WaveSyncDb) -> Self {
+        Self { db }
+    }
+
+    /// Wrap a web [`WebSyncClient`] signal. The signal pattern matches
+    /// the typical browser setup where the client is constructed async
+    /// during a `use_hook` and lives in a `Signal<Option<WebSyncClient>>`
+    /// until the initial connect resolves.
+    #[cfg(target_arch = "wasm32")]
+    pub fn new(client: Signal<Option<WebSyncClient>>) -> Self {
+        Self { client }
+    }
+
+    /// Escape hatch: borrow the underlying native database for SeaORM
+    /// operations the unified API doesn't cover (raw SQL, custom queries,
+    /// transactions, etc.). Code that uses this is non-portable to wasm32.
+    #[cfg(not(target_arch = "wasm32"))]
+    pub fn db(&self) -> &WaveSyncDb {
+        &self.db
+    }
+
+    /// Escape hatch: borrow the underlying web client signal for
+    /// browser-only operations (peer status, presence pings, etc.).
+    /// Code that uses this is non-portable to native targets.
+    #[cfg(target_arch = "wasm32")]
+    pub fn client(&self) -> Signal<Option<WebSyncClient>> {
+        self.client
+    }
+
+    /// Persist a row.
+    ///
+    /// On native, converts the entity to its `ActiveModel` and calls
+    /// `save()` — SeaORM's upsert path. The write goes through the
+    /// `WaveSyncDb` interception layer and broadcasts a
+    /// `ChangeNotification` to subscribers.
+    ///
+    /// On wasm32, dispatches to [`WebSyncClient::submit`] with the
+    /// table name resolved from `E::table_name()`. The browser engine
+    /// persists to the IndexedDB shadow table and broadcasts a
+    /// `ColumnChange` to subscribers.
+    ///
+    /// Either path is no-op-safe to spawn from a Dioxus event handler;
+    /// `submit` is async and intended to be called inside a `spawn`.
+    pub async fn submit<E>(&self, entity: &E) -> Result<(), SyncSubmitError>
+    where
+        E: SyncedTableEntity,
+    {
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            use ::sea_orm::ActiveModelTrait;
+            // `IntoActiveModel<E::ActiveModel>` is a supertrait of
+            // `SyncedTableEntity` on native, so `into_active_model`
+            // is in scope without an explicit `use`.
+            let am: E::ActiveModel = entity.clone().into_active_model();
+            am.save(&self.db).await?;
+            Ok(())
+        }
+        #[cfg(target_arch = "wasm32")]
+        {
+            let Some(client) = self.client.read().clone() else {
+                return Err(SyncSubmitError::NotConnected);
+            };
+            client.submit::<E>(E::table_name(), entity).await?;
+            Ok(())
+        }
+    }
+}
+
+/// Error returned by [`SyncHandle::submit`]. The variants are
+/// target-gated so each target sees only the failure modes its
+/// backend can produce.
+#[cfg(not(target_arch = "wasm32"))]
+#[derive(Debug)]
+pub enum SyncSubmitError {
+    /// SeaORM returned an error from `save()` — connection issue,
+    /// constraint violation, etc.
+    Db(::sea_orm::DbErr),
+}
+
+#[cfg(target_arch = "wasm32")]
+#[derive(Debug)]
+pub enum SyncSubmitError {
+    /// Browser sync engine returned an error — usually IndexedDB
+    /// persistence or shadow-table write failure.
+    Web(crate::WebSyncError),
+    /// The web client signal is still `None` — connect hasn't resolved
+    /// yet. UI code can retry once the connect future completes.
+    NotConnected,
+}
+
+impl ::std::fmt::Display for SyncSubmitError {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        match self {
+            #[cfg(not(target_arch = "wasm32"))]
+            SyncSubmitError::Db(e) => write!(f, "db error: {e}"),
+            #[cfg(target_arch = "wasm32")]
+            SyncSubmitError::Web(e) => write!(f, "web sync error: {e}"),
+            #[cfg(target_arch = "wasm32")]
+            SyncSubmitError::NotConnected => write!(f, "web client not connected"),
+        }
+    }
+}
+
+impl ::std::error::Error for SyncSubmitError {}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl From<::sea_orm::DbErr> for SyncSubmitError {
+    fn from(e: ::sea_orm::DbErr) -> Self {
+        SyncSubmitError::Db(e)
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+impl From<crate::WebSyncError> for SyncSubmitError {
+    fn from(e: crate::WebSyncError) -> Self {
+        SyncSubmitError::Web(e)
+    }
+}
+
+/// Reactive `Vec<E>` materialized from a synced table, target-agnostic.
+///
+/// Dispatches to the backend-specific implementation based on which
+/// transport `handle` wraps:
+///
+/// - Native (`cfg(not(target_arch = "wasm32"))`): delegates to
+///   [`super::use_synced_table_db`] with `E::Entity` — SeaORM does the
+///   initial load and the per-column patching uses `SyncedModel`.
+/// - Web (`cfg(target_arch = "wasm32")`): delegates to
+///   [`super::use_synced_table_client`] with `E::table_name()` — reads
+///   from IndexedDB and folds resolved `ColumnChange` events.
+///
+/// Both paths return `Signal<Vec<E>>` (note: on native, the Entity's
+/// `Model` is the user's struct `E` — the unified type means no
+/// `E::Model` indirection at the UI call site).
+///
+/// The two function definitions below have intentionally different
+/// where-clauses because each target needs different downstream
+/// bounds, and `#[cfg(...)]` on individual where predicates is still
+/// unstable — keeping the cfg at the function level dodges that.
+#[cfg(not(target_arch = "wasm32"))]
+pub fn use_synced_table<E>(handle: SyncHandle) -> Signal<Vec<E>>
+where
+    E: SyncedTableEntity,
+    <<E::Entity as ::sea_orm::EntityTrait>::PrimaryKey as ::sea_orm::PrimaryKeyTrait>::ValueType:
+        Clone + Send + Sync + 'static + Into<::sea_orm::Value> + From<String>,
+{
+    super::use_synced_table_db::<E::Entity>(handle.db)
+}
+
+#[cfg(target_arch = "wasm32")]
+pub fn use_synced_table<E: SyncedTableEntity>(handle: SyncHandle) -> Signal<Vec<E>> {
+    super::use_synced_table_client::<E>(handle.client, E::table_name())
+}

--- a/wavesyncdb/src/dioxus/web_hooks.rs
+++ b/wavesyncdb/src/dioxus/web_hooks.rs
@@ -4,7 +4,13 @@
 //! is the single source of truth for application state, and components
 //! drive themselves off a reactive stream of changes.
 //!
-//! [`use_synced_table::<E>(client, table)`] returns a
+//! **Most apps should use the cross-target
+//! [`super::use_synced_table`] instead** — it takes a
+//! [`SyncHandle`](super::SyncHandle) and works identically on native
+//! and wasm32. The hook below is the web-only escape hatch for code
+//! that already holds a `Signal<Option<WebSyncClient>>` directly.
+//!
+//! [`use_synced_table_client::<E>(client, table)`] returns a
 //! `Signal<Vec<E>>` that:
 //!
 //! 1. On the first render where `client` is `Some`, materializes the
@@ -44,7 +50,7 @@ use crate::web_entity::BrowserEntity;
 ///
 /// `table` is captured by value (`String`) so the hook can use it from
 /// the spawned subscription task without lifetime gymnastics.
-pub fn use_synced_table<E: BrowserEntity>(
+pub fn use_synced_table_client<E: BrowserEntity>(
     client: Signal<Option<WebSyncClient>>,
     table: &'static str,
 ) -> Signal<Vec<E>> {

--- a/wavesyncdb/src/lib.rs
+++ b/wavesyncdb/src/lib.rs
@@ -47,6 +47,7 @@ pub mod network_status;
 pub mod protocol;
 pub mod registry;
 pub mod synced_model;
+pub mod synced_table;
 
 // Native-only modules: anything that touches sea-orm (SQLite), libp2p
 // transports, tokio I/O, the local filesystem, or platform FFI. The
@@ -102,6 +103,7 @@ pub use network_status::{NatStatus, NetworkEvent, NetworkStatus, PeerId, PeerInf
 pub use registry::SyncEntityInfo;
 pub use registry::{TableMeta, TableRegistry};
 pub use synced_model::SyncedModel;
+pub use synced_table::SyncedTableEntity;
 
 /// Returns recommended log module filter tuples for silencing noisy dependencies.
 ///

--- a/wavesyncdb/src/lib.rs
+++ b/wavesyncdb/src/lib.rs
@@ -171,7 +171,7 @@ pub use sea_orm;
 // declare serde_json as a direct dependency.
 pub use serde_json;
 
-#[cfg(all(feature = "derive", not(target_arch = "wasm32")))]
+#[cfg(feature = "derive")]
 pub use wavesyncdb_derive::SyncEntity;
 
 #[cfg(feature = "dioxus")]

--- a/wavesyncdb/src/synced_table.rs
+++ b/wavesyncdb/src/synced_table.rs
@@ -1,0 +1,58 @@
+//! Cross-target metadata trait that lets [`dioxus::use_synced_table`]
+//! and [`dioxus::SyncHandle`] hide native-vs-web differences behind a
+//! single signature.
+//!
+//! Users almost always derive this via `#[derive(SyncEntity)]` — the
+//! same derive that emits `impl SyncedModel` on native and
+//! `impl BrowserEntity` on wasm32 also emits `impl SyncedTableEntity`
+//! on both targets so the same struct works in shared UI components.
+//!
+//! [`dioxus::use_synced_table`]: crate::dioxus::use_synced_table
+//! [`dioxus::SyncHandle`]: crate::dioxus::SyncHandle
+
+#[cfg(not(target_arch = "wasm32"))]
+use crate::synced_model::SyncedModel;
+
+/// Native trait: the entity carries a SeaORM `EntityTrait` association
+/// so the unified hook can issue queries via `E::Entity::find()`.
+///
+/// Implementations also satisfy [`SyncedModel`] — the same supertrait
+/// the native `use_synced_table_db` hook uses to apply column changes
+/// in place without a DB round trip.
+#[cfg(not(target_arch = "wasm32"))]
+pub trait SyncedTableEntity:
+    SyncedModel + ::sea_orm::FromQueryResult + Clone + Send + Sync + 'static
+where
+    Self: ::sea_orm::IntoActiveModel<<Self as SyncedTableEntity>::ActiveModel>,
+{
+    /// The SeaORM `Entity` type whose `Model` is `Self`.
+    type Entity: ::sea_orm::EntityTrait<Model = Self>;
+
+    /// The active-model type used by [`crate::dioxus::SyncHandle::submit`]
+    /// to insert/upsert rows. `DeriveEntityModel` generates this
+    /// alongside the entity. The `IntoActiveModel` supertrait bound
+    /// (above) is what makes `submit` able to call
+    /// `entity.clone().into_active_model()` without a per-method bound.
+    type ActiveModel: ::sea_orm::ActiveModelTrait<Entity = Self::Entity>
+        + ::sea_orm::ActiveModelBehavior
+        + Send;
+
+    /// The table name registered with the engine — pulled from
+    /// `#[sea_orm(table_name = "...")]` at the struct level.
+    fn table_name() -> &'static str;
+}
+
+/// Web trait: the entity carries the column-bag round-trip impl
+/// (`from_columns`/`to_columns`) via [`BrowserEntity`], plus the table
+/// name so the unified hook doesn't need a separate `&str` parameter.
+///
+/// [`BrowserEntity`]: crate::BrowserEntity
+#[cfg(target_arch = "wasm32")]
+pub trait SyncedTableEntity: crate::BrowserEntity {
+    /// The table name registered with the engine — pulled from
+    /// `#[sea_orm(table_name = "...")]` at the struct level. The
+    /// derive parses this on both targets even though no SeaORM types
+    /// are involved on wasm32; the `sea_orm` helper attribute is
+    /// claimed by `SyncEntity`'s `attributes(sea_orm)` declaration.
+    fn table_name() -> &'static str;
+}

--- a/wavesyncdb/src/web_entity.rs
+++ b/wavesyncdb/src/web_entity.rs
@@ -1,46 +1,39 @@
 //! Browser-side mapping between a Rust struct and the engine's
 //! column-bag representation.
 //!
-//! On native, the [`SyncEntity`](crate::SyncEntity) derive macro lives
-//! on top of SeaORM and tells the engine how to serialize / deserialize
-//! a row. The browser path has no SeaORM, so this trait is the explicit
-//! contract apps implement to plug their domain types into
-//! [`use_synced_table`](crate::dioxus::use_synced_table) and
-//! [`WebSyncClient::submit`](crate::WebSyncClient::submit).
+//! Most apps will derive this trait via [`SyncEntity`](crate::SyncEntity).
+//! The same derive that emits SeaORM glue on native targets emits an
+//! `impl BrowserEntity` on wasm — so a single struct definition powers
+//! both [`use_synced_table`](crate::dioxus::use_synced_table) and
+//! [`WebSyncClient::submit`](crate::WebSyncClient::submit) without
+//! parallel mirror types.
 //!
-//! Implementing it is mechanical — extract each field from the column
-//! map in `from_columns`, dump each field back into a `(name, value)`
-//! list in `to_columns`, return your primary-key field as a string in
-//! `pk`. There's no derive macro yet; with patterns on a few apps it
-//! could be added.
-//!
-//! ## Example
+//! ## Derive (recommended)
 //!
 //! ```ignore
-//! use std::collections::HashMap;
-//! use serde_json::Value;
-//! use wavesyncdb::BrowserEntity;
+//! use wavesyncdb::SyncEntity;
 //!
-//! #[derive(Clone, Debug)]
-//! struct Task { id: String, title: String, done: bool }
-//!
-//! impl BrowserEntity for Task {
-//!     fn from_columns(pk: &str, cols: &HashMap<String, Value>) -> Self {
-//!         Task {
-//!             id: pk.to_string(),
-//!             title: cols.get("title").and_then(|v| v.as_str()).unwrap_or("").to_string(),
-//!             done: cols.get("done").and_then(|v| v.as_bool()).unwrap_or(false),
-//!         }
-//!     }
-//!     fn to_columns(&self) -> Vec<(String, Value)> {
-//!         vec![
-//!             ("title".into(), Value::String(self.title.clone())),
-//!             ("done".into(), Value::Bool(self.done)),
-//!         ]
-//!     }
-//!     fn pk(&self) -> String { self.id.clone() }
+//! #[derive(Clone, Debug, Default, SyncEntity)]
+//! pub struct Task {
+//!     #[sea_orm(primary_key)]
+//!     pub id: String,
+//!     pub title: String,
+//!     pub done: bool,
 //! }
 //! ```
+//!
+//! Each non-PK field must implement `Serialize + DeserializeOwned +
+//! Default` — every common SeaORM-friendly field type (primitives,
+//! `String`, `Option<T>`, `Vec<u8>`, chrono dates) does.
+//!
+//! ## Manual impl (escape hatch)
+//!
+//! If a field needs custom packing (e.g., a non-`Default` type, or a
+//! field that shouldn't round-trip through JSON), implement the trait
+//! by hand instead of deriving it. Extract each field from the column
+//! map in `from_columns`, dump each field back into a `(name, value)`
+//! list in `to_columns`, return your primary-key field as a string in
+//! `pk`.
 
 use std::collections::HashMap;
 

--- a/wavesyncdb_derive/src/lib.rs
+++ b/wavesyncdb_derive/src/lib.rs
@@ -2,24 +2,63 @@ use proc_macro::TokenStream;
 use quote::quote;
 use syn::{Data, DeriveInput, Fields, parse_macro_input, spanned::Spanned};
 
-/// Derive macro that
+/// Derive macro that emits the per-target glue needed to plug a Rust
+/// struct into WaveSyncDB's sync engine.
 ///
-/// 1. registers a SeaORM entity for auto-discovery by
-///    `WaveSyncDb::get_schema_registry`, and
-/// 2. emits an `impl wavesyncdb::SyncedModel for Model` so the Dioxus
-///    reactive hooks can apply per-column changes from `ChangeNotification`
-///    in place — no DB round-trip on the receive path.
+/// **On native targets (`cfg(not(target_arch = "wasm32"))`):**
 ///
-/// Place this alongside `DeriveEntityModel` on your `Model` struct:
+/// 1. Registers a SeaORM entity for auto-discovery by
+///    `WaveSyncDb::get_schema_registry`.
+/// 2. Emits `impl SyncedModel` so the Dioxus reactive hooks can apply
+///    per-column changes from `ChangeNotification` in place — no DB
+///    round-trip on the receive path.
+///
+/// **On wasm32:**
+///
+/// Emits `impl BrowserEntity` so the same struct works with
+/// `WebSyncClient::submit` and the web `use_synced_table` hook.
+/// Field values round-trip through `serde_json::Value`, so each non-PK
+/// field must implement `Serialize + DeserializeOwned + Default`
+/// (primitives, `String`, `Option<T>`, `Vec<u8>`, chrono dates — all
+/// satisfy this out of the box).
+///
+/// ## Patterns
+///
+/// **Wasm-only entity** (e.g. for a browser-only demo):
 ///
 /// ```ignore
-/// #[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel, SyncEntity)]
-/// #[sea_orm(table_name = "tasks")]
-/// pub struct Model { ... }
+/// #[derive(Clone, Debug, Default, SyncEntity)]
+/// pub struct Task {
+///     #[sea_orm(primary_key)]
+///     pub id: String,
+///     pub title: String,
+///     pub done: bool,
+/// }
+/// ```
+///
+/// **Shared across native and wasm** (one source of truth — the
+/// SeaORM derives are conditional, but `SyncEntity` is unconditional and
+/// claims the `#[sea_orm(...)]` helper attribute on both targets):
+///
+/// ```ignore
+/// #[derive(Clone, Debug, Default, SyncEntity)]
+/// #[cfg_attr(not(target_arch = "wasm32"), derive(sea_orm::DeriveEntityModel))]
+/// #[cfg_attr(not(target_arch = "wasm32"), sea_orm(table_name = "tasks"))]
+/// pub struct Model {
+///     #[sea_orm(primary_key)]
+///     pub id: String,
+///     pub title: String,
+///     pub done: bool,
+/// }
 /// ```
 #[proc_macro_derive(SyncEntity, attributes(sea_orm))]
 pub fn derive_sync_entity(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
+
+    let meta = match collect_field_meta(&input) {
+        Ok(m) => m,
+        Err(e) => return e.to_compile_error().into(),
+    };
 
     let inventory_block = quote! {
         wavesyncdb::register_sync_entity! {
@@ -56,28 +95,43 @@ pub fn derive_sync_entity(input: TokenStream) -> TokenStream {
         }
     };
 
-    let synced_model_impl = match build_synced_model_impl(&input) {
-        Ok(ts) => ts,
-        Err(e) => return e.to_compile_error().into(),
-    };
+    let synced_model_body = build_synced_model_body(&meta);
+    let browser_entity_body = build_browser_entity_body(&meta);
 
     let model_ident = &input.ident;
     let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
 
     quote! {
+        #[cfg(not(target_arch = "wasm32"))]
         #inventory_block
 
+        #[cfg(not(target_arch = "wasm32"))]
         #[automatically_derived]
-        impl #impl_generics wavesyncdb::SyncedModel for #model_ident #ty_generics #where_clause {
-            #synced_model_impl
+        impl #impl_generics ::wavesyncdb::SyncedModel for #model_ident #ty_generics #where_clause {
+            #synced_model_body
+        }
+
+        #[cfg(target_arch = "wasm32")]
+        #[automatically_derived]
+        impl #impl_generics ::wavesyncdb::BrowserEntity for #model_ident #ty_generics #where_clause {
+            #browser_entity_body
         }
     }
     .into()
 }
 
-/// Walks the struct's named fields, finds the field marked
-/// `#[sea_orm(primary_key)]`, and emits the three trait-method bodies.
-fn build_synced_model_impl(input: &DeriveInput) -> syn::Result<proc_macro2::TokenStream> {
+struct FieldMeta {
+    field_idents: Vec<syn::Ident>,
+    field_types: Vec<syn::Type>,
+    field_lits: Vec<String>,
+    pk_ident: syn::Ident,
+    pk_type: syn::Type,
+}
+
+/// Walks the struct's named fields and identifies the field marked
+/// `#[sea_orm(primary_key)]`. Shared between the native and wasm
+/// codegen paths.
+fn collect_field_meta(input: &DeriveInput) -> syn::Result<FieldMeta> {
     let fields = match &input.data {
         Data::Struct(s) => match &s.fields {
             Fields::Named(named) => &named.named,
@@ -123,6 +177,26 @@ fn build_synced_model_impl(input: &DeriveInput) -> syn::Result<proc_macro2::Toke
         )
     })?;
 
+    Ok(FieldMeta {
+        field_idents,
+        field_types,
+        field_lits,
+        pk_ident,
+        pk_type,
+    })
+}
+
+/// Generates the three `SyncedModel` trait methods used by the native
+/// Dioxus reactive hooks to apply per-column changes in place.
+fn build_synced_model_body(meta: &FieldMeta) -> proc_macro2::TokenStream {
+    let FieldMeta {
+        field_idents,
+        field_types,
+        field_lits,
+        pk_ident,
+        pk_type,
+    } = meta;
+
     // Local binding names used inside `wavesync_from_changes` to avoid
     // shadowing the struct field name when constructing the final value.
     let local_idents: Vec<syn::Ident> = field_idents
@@ -132,11 +206,11 @@ fn build_synced_model_impl(input: &DeriveInput) -> syn::Result<proc_macro2::Toke
     let pk_local = local_idents
         .iter()
         .zip(field_idents.iter())
-        .find(|(_, fi)| **fi == pk_ident)
+        .find(|(_, fi)| *fi == pk_ident)
         .map(|(li, _)| li.clone())
         .expect("pk ident must be in field list");
 
-    Ok(quote! {
+    quote! {
         fn wavesync_apply_change(&mut self, column: &str, value: &::wavesyncdb::serde_json::Value) {
             match column {
                 #(
@@ -191,7 +265,83 @@ fn build_synced_model_impl(input: &DeriveInput) -> syn::Result<proc_macro2::Toke
         fn wavesync_pk_string(&self) -> ::std::string::String {
             ::std::format!("{}", self.#pk_ident)
         }
-    })
+    }
+}
+
+/// Generates `impl BrowserEntity` — bidirectional mapping between a
+/// Rust struct and the engine's column-bag wire shape. Each non-PK field
+/// is serialized via `serde_json::to_value` on submit and deserialized
+/// via `serde_json::from_value` on receive; missing columns fall back to
+/// `Default::default()` so the trait method can return `Self` directly
+/// (the trait has no `Option<Self>` return path).
+fn build_browser_entity_body(meta: &FieldMeta) -> proc_macro2::TokenStream {
+    let pk_ident = &meta.pk_ident;
+    let pk_type = &meta.pk_type;
+
+    // Partition into PK and non-PK fields. `to_columns` deliberately
+    // omits the PK — the trait's contract is that callers pass it
+    // separately via `pk()`.
+    let mut non_pk_idents = Vec::new();
+    let mut non_pk_types = Vec::new();
+    let mut non_pk_lits = Vec::new();
+    for ((id, ty), lit) in meta
+        .field_idents
+        .iter()
+        .zip(meta.field_types.iter())
+        .zip(meta.field_lits.iter())
+    {
+        if id != pk_ident {
+            non_pk_idents.push(id.clone());
+            non_pk_types.push(ty.clone());
+            non_pk_lits.push(lit.clone());
+        }
+    }
+
+    quote! {
+        fn from_columns(
+            pk: &str,
+            cols: &::std::collections::HashMap<::std::string::String, ::wavesyncdb::serde_json::Value>,
+        ) -> Self {
+            // PK parsing chain mirrors the native `wavesync_from_changes`
+            // path: try `from_value(Value::String(...))` first (covers
+            // String and Uuid), then fall back to `from_str` (covers
+            // numeric PKs where serde_json doesn't auto-convert from a
+            // JSON string).
+            let __pk_val: #pk_type = ::wavesyncdb::serde_json::from_value::<#pk_type>(
+                ::wavesyncdb::serde_json::Value::String(pk.to_string()),
+            )
+            .ok()
+            .or_else(|| ::wavesyncdb::serde_json::from_str::<#pk_type>(pk).ok())
+            .unwrap_or_default();
+
+            Self {
+                #pk_ident: __pk_val,
+                #(
+                    #non_pk_idents: cols
+                        .get(#non_pk_lits)
+                        .and_then(|__v| ::wavesyncdb::serde_json::from_value::<#non_pk_types>(__v.clone()).ok())
+                        .unwrap_or_default(),
+                )*
+            }
+        }
+
+        fn to_columns(&self) -> ::std::vec::Vec<(::std::string::String, ::wavesyncdb::serde_json::Value)> {
+            let mut __out: ::std::vec::Vec<(::std::string::String, ::wavesyncdb::serde_json::Value)>
+                = ::std::vec::Vec::new();
+            #(
+                __out.push((
+                    ::std::string::ToString::to_string(#non_pk_lits),
+                    ::wavesyncdb::serde_json::to_value(&self.#non_pk_idents)
+                        .unwrap_or(::wavesyncdb::serde_json::Value::Null),
+                ));
+            )*
+            __out
+        }
+
+        fn pk(&self) -> ::std::string::String {
+            ::std::format!("{}", self.#pk_ident)
+        }
+    }
 }
 
 /// True if the field carries `#[sea_orm(primary_key)]` (with or without

--- a/wavesyncdb_derive/src/lib.rs
+++ b/wavesyncdb_derive/src/lib.rs
@@ -160,20 +160,21 @@ fn parse_table_name(input: &DeriveInput) -> syn::Result<String> {
         }
         let mut table_name: Option<String> = None;
         let mut parse_err: Option<syn::Error> = None;
-        let _ = attr.parse_nested_meta(|meta| {
-            if meta.path.is_ident("table_name") {
-                let value = meta.value()?;
-                let lit: syn::LitStr = value.parse()?;
-                table_name = Some(lit.value());
-            } else if meta.input.peek(syn::Token![=]) {
-                // Skip past any `= ...` value for keys we don't care about
-                // so the parser doesn't error on them.
-                let _: syn::Token![=] = meta.input.parse()?;
-                let _: proc_macro2::TokenStream = meta.input.parse()?;
-            }
-            Ok(())
-        })
-        .map_err(|e| parse_err = Some(e));
+        let _ = attr
+            .parse_nested_meta(|meta| {
+                if meta.path.is_ident("table_name") {
+                    let value = meta.value()?;
+                    let lit: syn::LitStr = value.parse()?;
+                    table_name = Some(lit.value());
+                } else if meta.input.peek(syn::Token![=]) {
+                    // Skip past any `= ...` value for keys we don't care about
+                    // so the parser doesn't error on them.
+                    let _: syn::Token![=] = meta.input.parse()?;
+                    let _: proc_macro2::TokenStream = meta.input.parse()?;
+                }
+                Ok(())
+            })
+            .map_err(|e| parse_err = Some(e));
         if let Some(e) = parse_err {
             return Err(e);
         }

--- a/wavesyncdb_derive/src/lib.rs
+++ b/wavesyncdb_derive/src/lib.rs
@@ -60,6 +60,11 @@ pub fn derive_sync_entity(input: TokenStream) -> TokenStream {
         Err(e) => return e.to_compile_error().into(),
     };
 
+    let table_name = match parse_table_name(&input) {
+        Ok(name) => name,
+        Err(e) => return e.to_compile_error().into(),
+    };
+
     let inventory_block = quote! {
         wavesyncdb::register_sync_entity! {
             wavesyncdb::SyncEntityInfo {
@@ -116,8 +121,70 @@ pub fn derive_sync_entity(input: TokenStream) -> TokenStream {
         impl #impl_generics ::wavesyncdb::BrowserEntity for #model_ident #ty_generics #where_clause {
             #browser_entity_body
         }
+
+        // The cross-target metadata trait that lets the unified
+        // `wavesyncdb::dioxus::use_synced_table` hook work without
+        // cfg gating at the UI call site. On native it carries the
+        // SeaORM Entity + ActiveModel associations; on wasm it carries
+        // only the table name (the column round-trip lives in
+        // `BrowserEntity`). The sibling identifiers `Entity` and
+        // `ActiveModel` referenced below come from `DeriveEntityModel`
+        // (or any compatible derive) in the same module as the user's
+        // struct.
+        #[cfg(not(target_arch = "wasm32"))]
+        #[automatically_derived]
+        impl #impl_generics ::wavesyncdb::SyncedTableEntity for #model_ident #ty_generics #where_clause {
+            type Entity = Entity;
+            type ActiveModel = ActiveModel;
+            fn table_name() -> &'static str { #table_name }
+        }
+
+        #[cfg(target_arch = "wasm32")]
+        #[automatically_derived]
+        impl #impl_generics ::wavesyncdb::SyncedTableEntity for #model_ident #ty_generics #where_clause {
+            fn table_name() -> &'static str { #table_name }
+        }
     }
     .into()
+}
+
+/// Parse the table name from the struct-level `#[sea_orm(table_name = "...")]`
+/// attribute. Required on both native and wasm32 targets — on wasm there's
+/// no `DeriveEntityModel` to consume it, but `SyncEntity` claims it via
+/// `attributes(sea_orm)` so the compiler accepts it and the macro reads it
+/// to populate `SyncedTableEntity::table_name()`.
+fn parse_table_name(input: &DeriveInput) -> syn::Result<String> {
+    for attr in &input.attrs {
+        if !attr.path().is_ident("sea_orm") {
+            continue;
+        }
+        let mut table_name: Option<String> = None;
+        let mut parse_err: Option<syn::Error> = None;
+        let _ = attr.parse_nested_meta(|meta| {
+            if meta.path.is_ident("table_name") {
+                let value = meta.value()?;
+                let lit: syn::LitStr = value.parse()?;
+                table_name = Some(lit.value());
+            } else if meta.input.peek(syn::Token![=]) {
+                // Skip past any `= ...` value for keys we don't care about
+                // so the parser doesn't error on them.
+                let _: syn::Token![=] = meta.input.parse()?;
+                let _: proc_macro2::TokenStream = meta.input.parse()?;
+            }
+            Ok(())
+        })
+        .map_err(|e| parse_err = Some(e));
+        if let Some(e) = parse_err {
+            return Err(e);
+        }
+        if let Some(name) = table_name {
+            return Ok(name);
+        }
+    }
+    Err(syn::Error::new(
+        input.span(),
+        "SyncEntity requires `#[sea_orm(table_name = \"...\")]` at the struct level — needed to populate `SyncedTableEntity::table_name()`",
+    ))
 }
 
 struct FieldMeta {

--- a/website/src/pages/todo_demo.rs
+++ b/website/src/pages/todo_demo.rs
@@ -17,15 +17,16 @@
 
 use dioxus::prelude::*;
 use wavesyncdb::{
-    LoopbackLink, LoopbackPair, SyncEntity, WebSyncClient, dioxus::use_synced_table,
+    LoopbackLink, LoopbackPair, SyncEntity, WebSyncClient,
+    dioxus::{SyncHandle, use_synced_table},
 };
 
 const TOPIC: &str = "wavesync-local-demo";
 const STORE_LAPTOP: &str = "local-demo-laptop";
 const STORE_PHONE: &str = "local-demo-phone";
-const TASK_TABLE: &str = "tasks";
 
 #[derive(Clone, Debug, Default, SyncEntity)]
+#[sea_orm(table_name = "tasks")]
 struct Task {
     #[sea_orm(primary_key)]
     id: String,
@@ -166,7 +167,8 @@ fn DeviceBody(
     // The reactive view: tasks materialize from IndexedDB on first
     // client-ready, then auto-update on every local or remote change
     // via subscribe_resolved. No HashMap, no manual merge.
-    let tasks = use_synced_table::<Task>(client, TASK_TABLE);
+    let handle = SyncHandle::new(client);
+    let tasks = use_synced_table::<Task>(handle);
     let mut new_title = use_signal(String::new);
     let connected = client().is_some();
     let is_online = online();
@@ -184,7 +186,6 @@ fn DeviceBody(
         if title.is_empty() {
             return;
         }
-        let Some(c) = client() else { return };
         let task = Task {
             id: uuid_v4_string(),
             title,
@@ -194,23 +195,21 @@ fn DeviceBody(
         };
         new_title.set(String::new());
         spawn(async move {
-            let _ = c.submit::<Task>(TASK_TABLE, &task).await;
+            let _ = handle.submit(&task).await;
         });
     };
 
     let toggle_done = move |t: Task| {
-        let Some(c) = client() else { return };
         let updated = Task { done: !t.done, ..t };
         spawn(async move {
-            let _ = c.submit::<Task>(TASK_TABLE, &updated).await;
+            let _ = handle.submit(&updated).await;
         });
     };
 
     let delete_task = move |t: Task| {
-        let Some(c) = client() else { return };
         let updated = Task { deleted: true, ..t };
         spawn(async move {
-            let _ = c.submit::<Task>(TASK_TABLE, &updated).await;
+            let _ = handle.submit(&updated).await;
         });
     };
 

--- a/website/src/pages/todo_demo.rs
+++ b/website/src/pages/todo_demo.rs
@@ -15,11 +15,9 @@
 //! IndexedDB is the single source of truth; the component is a thin
 //! renderer over `Signal<Vec<Task>>`.
 
-use std::collections::HashMap;
-
 use dioxus::prelude::*;
 use wavesyncdb::{
-    BrowserEntity, LoopbackLink, LoopbackPair, WebSyncClient, dioxus::use_synced_table, serde_json,
+    LoopbackLink, LoopbackPair, SyncEntity, WebSyncClient, dioxus::use_synced_table,
 };
 
 const TOPIC: &str = "wavesync-local-demo";
@@ -27,51 +25,14 @@ const STORE_LAPTOP: &str = "local-demo-laptop";
 const STORE_PHONE: &str = "local-demo-phone";
 const TASK_TABLE: &str = "tasks";
 
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, SyncEntity)]
 struct Task {
+    #[sea_orm(primary_key)]
     id: String,
     title: String,
     done: bool,
     deleted: bool,
     created_at: u64,
-}
-
-impl BrowserEntity for Task {
-    fn from_columns(pk: &str, cols: &HashMap<String, serde_json::Value>) -> Self {
-        Task {
-            id: pk.to_string(),
-            title: cols
-                .get("title")
-                .and_then(|v| v.as_str())
-                .unwrap_or("(untitled)")
-                .to_string(),
-            done: cols.get("done").and_then(|v| v.as_bool()).unwrap_or(false),
-            deleted: cols
-                .get("deleted")
-                .and_then(|v| v.as_bool())
-                .unwrap_or(false),
-            created_at: cols.get("created_at").and_then(|v| v.as_u64()).unwrap_or(0),
-        }
-    }
-
-    fn to_columns(&self) -> Vec<(String, serde_json::Value)> {
-        vec![
-            (
-                "title".to_string(),
-                serde_json::Value::String(self.title.clone()),
-            ),
-            ("done".to_string(), serde_json::Value::Bool(self.done)),
-            ("deleted".to_string(), serde_json::Value::Bool(self.deleted)),
-            (
-                "created_at".to_string(),
-                serde_json::Value::Number(serde_json::Number::from(self.created_at)),
-            ),
-        ]
-    }
-
-    fn pk(&self) -> String {
-        self.id.clone()
-    }
 }
 
 #[component]


### PR DESCRIPTION
## Summary

Removes two long-standing wasm-vs-native DX cliffs in WaveSyncDB's Dioxus integration. Consuming apps that target both desktop/mobile and browser (e.g. Mediterranea) can now define each sync entity **once** and share UI components verbatim.

### Problem 1 — Duplicate entity definitions

Before: every synced entity needed two parallel declarations. A SeaORM `Model` with `#[derive(SyncEntity)]` on native, and a separate `Task`-shaped struct with a hand-written `impl BrowserEntity` (≈30 lines of column-bag unpacking per entity) on web. An app with 9 synced entities paid this tax 9 times.

After: the `SyncEntity` derive emits per-target glue from a single source:

```rust
#[derive(Clone, Debug, Default, SyncEntity)]
#[cfg_attr(not(target_arch = "wasm32"), derive(sea_orm::DeriveEntityModel))]
#[cfg_attr(not(target_arch = "wasm32"), sea_orm(table_name = "tasks"))]
pub struct Model {
    #[sea_orm(primary_key)]
    pub id: String,
    pub title: String,
    pub done: bool,
}
```

- `cfg(not(target_arch = \"wasm32\"))`: `register_sync_entity!` for schema discovery + `impl SyncedModel` for in-place column patching (unchanged from the previous native blocks).
- `cfg(target_arch = \"wasm32\")`: `impl BrowserEntity` driven by `serde_json::Value` round-trips, so any field type that's `Serialize + DeserializeOwned + Default` (primitives, `String`, `Option<T>`, `Vec<u8>`, chrono dates) works without per-field shims.

The `#[sea_orm(...)]` attributes survive on wasm because `SyncEntity` declares them as helper attributes — the compiler accepts them even when `DeriveEntityModel` is conditionally absent.

### Problem 2 — Read/write hook signature split

Before: `use_synced_table::<E>(db: WaveSyncDb)` on native vs `use_synced_table::<E>(client, table: &'static str)` on wasm. Writes were entirely separate APIs (SeaORM `ActiveModel.save()` vs `WebSyncClient::submit(table, &entity)`). UI components couldn't be shared without splitting into per-target modules.

After: a unified call site on both targets:

```rust
#[component]
fn TaskList(handle: SyncHandle) -> Element {
    let tasks = use_synced_table::<Task>(handle);
    let do_add = use_callback(move |_| {
        let task = Task { /* ... */ };
        spawn(async move { let _ = handle.submit(&task).await; });
    });
    /* ... same body on native and wasm ... */
}

// Entry points construct the right backend:
//   native: TaskList { handle: SyncHandle::new(db) }
//   wasm:   TaskList { handle: SyncHandle::new(client_signal) }
```

`SyncHandle` is `Clone` on native (wraps `WaveSyncDb`) and `Clone + Copy` on wasm (wraps `Signal<Option<WebSyncClient>>` — `Signal` is `Copy`-by-design so the handle can be captured in event-handler closures without per-call cloning). A custom `PartialEq` returns `true` so Dioxus's prop-equality check doesn't force re-renders — the hook's internal subscriptions handle reactivity.

The unified hook dispatches to backend-specific implementations (renamed to `use_synced_table_db` and `use_synced_table_client`), which remain available as escape hatches for code that already holds a `WaveSyncDb` / `Signal<Option<WebSyncClient>>` directly or needs SeaORM-specific query options.

## Out of scope

- Hard deletes — apps using a `deleted: bool` soft-delete column (the `website/todo_demo` pattern) already work through `submit`. A cross-target `delete` API would be a separate followup.
- An auto-derive `use_sync_handle()` from `use_wavesync()` context. The current pattern of constructing `SyncHandle::new(db)` explicitly at the prop boundary keeps data flow obvious.

## Migration of internal call sites

- 4 native examples (`dioxus_app`, `dioxus_dynamic`, `dioxus_fcm_sync`, `qr_pairing/native_app`): `use_synced_table::<task::Entity>(db)` → `use_synced_table::<task::Model>(SyncHandle::new(db))`.
- 2 web sites (`qr_pairing/web_app`, `website/todo_demo`): dropped the `TASK_TABLE` constant and the manual `client.submit::<E>(TASK_TABLE, &entity)` calls in favor of `handle.submit(&entity)`. The `TaskList` component in `qr_pairing/web_app` now takes a `SyncHandle` prop instead of `Signal<Option<WebSyncClient>>` — exactly the shape a cross-target shared component would have.

Two in-repo manual `BrowserEntity` impls (`qr_pairing/web_app`, `website/todo_demo`) replaced by the derive — ≈70 lines of mechanical column-unpacking boilerplate removed.

## Test plan

- [x] `cargo clippy -p wavesyncdb -p wavesyncdb_derive -p wavesync_relay -- -D warnings` — clean
- [x] `cargo test -p wavesyncdb --lib` — 167 unit tests pass
- [x] `cargo test -p wavesyncdb --test integration -- --test-threads=1` — 19 integration tests pass
- [x] `cargo check --target wasm32-unknown-unknown -p wavesyncdb -p example-qr-pairing -p wavesync-website` — clean on all three
- [x] `cargo check -p example-qr-pairing` (native) — clean
- [ ] Manual: `dx serve --platform web` on the website and on `qr_pairing` to confirm the migrated UI still renders + the demo works end-to-end (pending — none of the dioxus-desktop examples are buildable via `cargo` because they need `dx` and platform-specific system libs (GTK/WebKit/xdo), so they're excluded from the cargo workspace)
