### PR TITLE
chore(wavesyncdb): bump to 0.6.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ exclude = [
 resolver = "3"
 
 [workspace.dependencies]
-wavesyncdb = { path = "wavesyncdb", version = "0.5.0" }
+wavesyncdb = { path = "wavesyncdb", version = "0.6.0" }
 wavesyncdb_derive = { path = "wavesyncdb_derive", version = "0.2.1" }
 sea-orm = { version = "2.0.0-rc", features = ["sqlx-sqlite", "runtime-tokio", "macros"] }
 serde = { version = "1.0", features = ["derive"] }

--- a/wavesyncdb/Cargo.toml
+++ b/wavesyncdb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wavesyncdb"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2024"
 license = "AGPL-3.0-or-later OR LicenseRef-Commercial"
 description = "WaveSyncDB is a lightweight, distributed database synchronization engine designed to bridge the gap between real-time data streaming and relational storage. It ensures high-consistency data replication across decentralized nodes with a focus on low-latency updates."


### PR DESCRIPTION
Minor bump under pre-1.0 semver for the breaking changes that just landed in #55.

## Breaking

- `wavesyncdb::dioxus::use_synced_table` signature changed on both targets — it now takes a `SyncHandle` and a `SyncedTableEntity` type parameter instead of the per-backend `(WaveSyncDb)` / `(client, table)` argument shapes. Old behavior is still available behind `use_synced_table_db` (native) and `use_synced_table_client` (web).
- `#[derive(SyncEntity)]` now requires `#[sea_orm(table_name = "...")]` at the struct level on all targets. Existing native users already satisfy this via `DeriveEntityModel`; wasm-only entities (added in this release) need it explicitly.

## Additive

- `BrowserEntity` auto-derived from `#[derive(SyncEntity)]` on wasm.
- New `SyncHandle` cross-target transport facade with `submit::<E>(&entity)`.
- New `SyncedTableEntity` metadata trait.

## Test plan

- [x] `cargo build -p wavesyncdb` — version compiles
- [ ] CI passes